### PR TITLE
fix: Do not track empty assignment events

### DIFF
--- a/src/main/kotlin/assignment/AssignmentFilter.kt
+++ b/src/main/kotlin/assignment/AssignmentFilter.kt
@@ -12,6 +12,9 @@ internal class InMemoryAssignmentFilter(size: Int, ttlMillis: Long = DAY_MILLIS)
     private val cache = Cache<String, Unit>(size, ttlMillis)
 
     override fun shouldTrack(assignment: Assignment): Boolean {
+        if (assignment.results.isEmpty()) {
+            return false
+        }
         val canonicalAssignment = assignment.canonicalize()
         val track = cache[canonicalAssignment] == null
         if (track) {

--- a/src/test/kotlin/assignment/AssignmentFilterTest.kt
+++ b/src/test/kotlin/assignment/AssignmentFilterTest.kt
@@ -89,7 +89,7 @@ class AssignmentFilterTest {
             ExperimentUser(userId = "user"),
             mapOf()
         )
-        Assert.assertTrue(filter.shouldTrack(assignment1))
+        Assert.assertFalse(filter.shouldTrack(assignment1))
         val assignment2 = Assignment(
             ExperimentUser(userId = "user"),
             mapOf()
@@ -99,7 +99,7 @@ class AssignmentFilterTest {
             ExperimentUser(userId = "different user"),
             mapOf()
         )
-        Assert.assertTrue(filter.shouldTrack(assignment3))
+        Assert.assertFalse(filter.shouldTrack(assignment3))
     }
 
     @Test


### PR DESCRIPTION
Employ fix: empty assignment events are not tracked