### PR TITLE
feat: add flag push

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     testImplementation("io.mockk:mockk:${Versions.mockk}")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.serializationRuntime}")
     implementation("com.squareup.okhttp3:okhttp:${Versions.okhttp}")
+    implementation("com.squareup.okhttp3:okhttp-sse:${Versions.okhttpSse}")
     implementation("com.amplitude:evaluation-core:${Versions.evaluationCore}")
     implementation("com.amplitude:java-sdk:${Versions.amplitudeAnalytics}")
     implementation("org.json:json:${Versions.json}")

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -6,7 +6,7 @@ object Versions {
     const val serializationRuntime = "1.4.1"
     const val json = "20231013"
     const val okhttp = "4.12.0"
-    const val okhttpSse = "4.12.0" // Update this alongside okhttp. Note this library isn't stable and may contain breaking changes.
+    const val okhttpSse = "4.12.0" // Update this alongside okhttp. Note this library isn't stable and may contain breaking changes. Search uses of okhttp3.internal classes before updating.
     const val evaluationCore = "2.0.0-beta.2"
     const val amplitudeAnalytics = "1.12.0"
     const val mockk = "1.13.9"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -6,6 +6,7 @@ object Versions {
     const val serializationRuntime = "1.4.1"
     const val json = "20231013"
     const val okhttp = "4.12.0"
+    const val okhttpSse = "4.12.0" // Update this alongside okhttp. Note this library isn't stable and may contain breaking changes.
     const val evaluationCore = "2.0.0-beta.2"
     const val amplitudeAnalytics = "1.12.0"
     const val mockk = "1.13.9"

--- a/src/main/kotlin/LocalEvaluationClient.kt
+++ b/src/main/kotlin/LocalEvaluationClient.kt
@@ -19,7 +19,6 @@ import com.amplitude.experiment.evaluation.EvaluationEngineImpl
 import com.amplitude.experiment.evaluation.EvaluationFlag
 import com.amplitude.experiment.evaluation.topologicalSort
 import com.amplitude.experiment.flag.DynamicFlagConfigApi
-import com.amplitude.experiment.flag.FlagConfigPoller
 import com.amplitude.experiment.flag.FlagConfigStreamApi
 import com.amplitude.experiment.flag.InMemoryFlagConfigStorage
 import com.amplitude.experiment.util.LocalEvaluationMetricsWrapper
@@ -34,10 +33,6 @@ import com.amplitude.experiment.util.wrapMetrics
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.sse.EventSource
-import okhttp3.sse.EventSourceListener
-import okhttp3.sse.EventSources
 
 class LocalEvaluationClient internal constructor(
     apiKey: String,

--- a/src/main/kotlin/LocalEvaluationClient.kt
+++ b/src/main/kotlin/LocalEvaluationClient.kt
@@ -34,6 +34,10 @@ import com.amplitude.experiment.util.wrapMetrics
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.sse.EventSource
+import okhttp3.sse.EventSourceListener
+import okhttp3.sse.EventSources
 
 class LocalEvaluationClient internal constructor(
     apiKey: String,

--- a/src/main/kotlin/LocalEvaluationClient.kt
+++ b/src/main/kotlin/LocalEvaluationClient.kt
@@ -237,9 +237,3 @@ private fun getEventServerUrl(
         assignmentConfiguration.serverUrl
     }
 }
-
-fun main() {
-    val client = LocalEvaluationClient("server-qz35UwzJ5akieoAdIgzM4m9MIiOLXLoz", LocalEvaluationConfig(streamUpdates = true))
-    client.start()
-    println(client.evaluateV2(ExperimentUser("1")))
-}

--- a/src/main/kotlin/LocalEvaluationConfig.kt
+++ b/src/main/kotlin/LocalEvaluationConfig.kt
@@ -22,6 +22,12 @@ class LocalEvaluationConfig internal constructor(
     @JvmField
     val flagConfigPollerRequestTimeoutMillis: Long = Defaults.FLAG_CONFIG_POLLER_REQUEST_TIMEOUT_MILLIS,
     @JvmField
+    val streamUpdates: Boolean = Defaults.STREAM_UPDATES,
+    @JvmField
+    val streamServerUrl: String = Defaults.STREAM_SERVER_URL,
+    @JvmField
+    val streamFlagConnTimeoutMillis: Long = Defaults.STREAM_FLAG_CONN_TIMEOUT_MILLIS,
+    @JvmField
     val assignmentConfiguration: AssignmentConfiguration? = Defaults.ASSIGNMENT_CONFIGURATION,
     @JvmField
     val cohortSyncConfig: CohortSyncConfig? = Defaults.COHORT_SYNC_CONFIGURATION,
@@ -76,6 +82,12 @@ class LocalEvaluationConfig internal constructor(
          */
         const val FLAG_CONFIG_POLLER_REQUEST_TIMEOUT_MILLIS = 10_000L
 
+        const val STREAM_UPDATES = false
+
+        const val STREAM_SERVER_URL = US_STREAM_SERVER_URL
+
+        const val STREAM_FLAG_CONN_TIMEOUT_MILLIS = 1_500L
+
         /**
          * null
          */
@@ -111,6 +123,9 @@ class LocalEvaluationConfig internal constructor(
         private var serverUrl = Defaults.SERVER_URL
         private var flagConfigPollerIntervalMillis = Defaults.FLAG_CONFIG_POLLER_INTERVAL_MILLIS
         private var flagConfigPollerRequestTimeoutMillis = Defaults.FLAG_CONFIG_POLLER_REQUEST_TIMEOUT_MILLIS
+        private var streamUpdates = Defaults.STREAM_UPDATES
+        private var streamServerUrl = Defaults.STREAM_SERVER_URL
+        private var streamFlagConnTimeoutMillis = Defaults.STREAM_FLAG_CONN_TIMEOUT_MILLIS
         private var assignmentConfiguration = Defaults.ASSIGNMENT_CONFIGURATION
         private var cohortSyncConfiguration = Defaults.COHORT_SYNC_CONFIGURATION
         private var evaluationProxyConfiguration = Defaults.EVALUATION_PROXY_CONFIGURATION
@@ -134,6 +149,18 @@ class LocalEvaluationConfig internal constructor(
 
         fun flagConfigPollerRequestTimeoutMillis(flagConfigPollerRequestTimeoutMillis: Long) = apply {
             this.flagConfigPollerRequestTimeoutMillis = flagConfigPollerRequestTimeoutMillis
+        }
+
+        fun streamUpdates(streamUpdates: Boolean) = apply {
+            this.streamUpdates = streamUpdates
+        }
+
+        fun streamServerUrl(streamServerUrl: String) = apply {
+            this.streamServerUrl = streamServerUrl
+        }
+
+        fun streamFlagConnTimeoutMillis(streamFlagConnTimeoutMillis: Long) = apply {
+            this.streamFlagConnTimeoutMillis = streamFlagConnTimeoutMillis
         }
 
         fun enableAssignmentTracking(assignmentConfiguration: AssignmentConfiguration) = apply {
@@ -161,6 +188,9 @@ class LocalEvaluationConfig internal constructor(
                 serverZone = serverZone,
                 flagConfigPollerIntervalMillis = flagConfigPollerIntervalMillis,
                 flagConfigPollerRequestTimeoutMillis = flagConfigPollerRequestTimeoutMillis,
+                streamUpdates = streamUpdates,
+                streamServerUrl = streamServerUrl,
+                streamFlagConnTimeoutMillis = streamFlagConnTimeoutMillis,
                 assignmentConfiguration = assignmentConfiguration,
                 cohortSyncConfig = cohortSyncConfiguration,
                 evaluationProxyConfig = evaluationProxyConfiguration,

--- a/src/main/kotlin/LocalEvaluationConfig.kt
+++ b/src/main/kotlin/LocalEvaluationConfig.kt
@@ -207,6 +207,8 @@ interface LocalEvaluationMetrics {
     fun onFlagConfigFetch()
     fun onFlagConfigFetchFailure(exception: Exception)
     fun onFlagConfigFetchOriginFallback(exception: Exception)
+    fun onFlagConfigStream()
+    fun onFlagConfigStreamFailure(exception: Exception?)
     fun onCohortDownload()
     fun onCohortDownloadFailure(exception: Exception)
     fun onCohortDownloadOriginFallback(exception: Exception)

--- a/src/main/kotlin/ServerZone.kt
+++ b/src/main/kotlin/ServerZone.kt
@@ -2,6 +2,8 @@ package com.amplitude.experiment
 
 internal const val US_SERVER_URL = "https://api.lab.amplitude.com"
 internal const val EU_SERVER_URL = "https://api.lab.eu.amplitude.com"
+internal const val US_STREAM_SERVER_URL = "https://stream.lab.amplitude.com"
+internal const val EU_STREAM_SERVER_URL = "https://stream.lab.eu.amplitude.com"
 internal const val US_COHORT_SERVER_URL = "https://cohort-v2.lab.amplitude.com"
 internal const val EU_COHORT_SERVER_URL = "https://cohort-v2.lab.eu.amplitude.com"
 internal const val US_EVENT_SERVER_URL = "https://api2.amplitude.com/2/httpapi"

--- a/src/main/kotlin/deployment/DeploymentRunner.kt
+++ b/src/main/kotlin/deployment/DeploymentRunner.kt
@@ -39,7 +39,10 @@ internal class DeploymentRunner(
     }
     private val cohortPollingInterval: Long = getCohortPollingInterval()
     // Fallback in this order: proxy, stream, poll.
-    private val amplitudeFlagConfigPoller = FlagConfigFallbackRetryWrapper(FlagConfigPoller(flagConfigApi, flagConfigStorage, cohortLoader, cohortStorage, config, metrics), null, config.flagConfigPollerIntervalMillis, 1000)
+    private val amplitudeFlagConfigPoller = FlagConfigFallbackRetryWrapper(
+        FlagConfigPoller(flagConfigApi, flagConfigStorage, cohortLoader, cohortStorage, config, metrics),
+        null, config.flagConfigPollerIntervalMillis, 1000
+    )
     private val amplitudeFlagConfigUpdater =
         if (flagConfigStreamApi != null)
             FlagConfigFallbackRetryWrapper(

--- a/src/main/kotlin/deployment/DeploymentRunner.kt
+++ b/src/main/kotlin/deployment/DeploymentRunner.kt
@@ -1,15 +1,16 @@
-@file:OptIn(ExperimentalApi::class)
-
 package com.amplitude.experiment.deployment
 
-import com.amplitude.experiment.*
+import com.amplitude.experiment.LocalEvaluationConfig
+import com.amplitude.experiment.LocalEvaluationMetrics
 import com.amplitude.experiment.cohort.CohortApi
 import com.amplitude.experiment.cohort.CohortLoader
 import com.amplitude.experiment.cohort.CohortStorage
-import com.amplitude.experiment.flag.*
 import com.amplitude.experiment.flag.FlagConfigApi
+import com.amplitude.experiment.flag.FlagConfigFallbackRetryWrapper
 import com.amplitude.experiment.flag.FlagConfigPoller
 import com.amplitude.experiment.flag.FlagConfigStorage
+import com.amplitude.experiment.flag.FlagConfigStreamApi
+import com.amplitude.experiment.flag.FlagConfigStreamer
 import com.amplitude.experiment.util.LocalEvaluationMetricsWrapper
 import com.amplitude.experiment.util.Logger
 import com.amplitude.experiment.util.Once
@@ -46,7 +47,7 @@ internal class DeploymentRunner(
     private val amplitudeFlagConfigUpdater =
         if (flagConfigStreamApi != null)
             FlagConfigFallbackRetryWrapper(
-                FlagConfigStreamer(flagConfigStreamApi, flagConfigStorage, cohortLoader, cohortStorage, config, metrics),
+                FlagConfigStreamer(flagConfigStreamApi, flagConfigStorage, cohortLoader, cohortStorage, metrics),
                 amplitudeFlagConfigPoller,
             )
         else amplitudeFlagConfigPoller

--- a/src/main/kotlin/deployment/DeploymentRunner.kt
+++ b/src/main/kotlin/deployment/DeploymentRunner.kt
@@ -39,7 +39,7 @@ internal class DeploymentRunner(
     }
     private val cohortPollingInterval: Long = getCohortPollingInterval()
     // Fallback in this order: proxy, stream, poll.
-    private val amplitudeFlagConfigPoller = FlagConfigPoller(flagConfigApi, flagConfigStorage, cohortLoader, cohortStorage, config, metrics)
+    private val amplitudeFlagConfigPoller = FlagConfigFallbackRetryWrapper(FlagConfigPoller(flagConfigApi, flagConfigStorage, cohortLoader, cohortStorage, config, metrics), null, config.flagConfigPollerIntervalMillis, 1000)
     private val amplitudeFlagConfigUpdater =
         if (flagConfigStreamApi != null)
             FlagConfigFallbackRetryWrapper(

--- a/src/main/kotlin/deployment/DeploymentRunner.kt
+++ b/src/main/kotlin/deployment/DeploymentRunner.kt
@@ -2,22 +2,19 @@
 
 package com.amplitude.experiment.deployment
 
-import com.amplitude.experiment.ExperimentalApi
-import com.amplitude.experiment.LocalEvaluationConfig
-import com.amplitude.experiment.LocalEvaluationMetrics
+import com.amplitude.experiment.*
 import com.amplitude.experiment.cohort.CohortApi
 import com.amplitude.experiment.cohort.CohortLoader
 import com.amplitude.experiment.cohort.CohortStorage
+import com.amplitude.experiment.flag.*
 import com.amplitude.experiment.flag.FlagConfigApi
+import com.amplitude.experiment.flag.FlagConfigPoller
 import com.amplitude.experiment.flag.FlagConfigStorage
 import com.amplitude.experiment.util.LocalEvaluationMetricsWrapper
 import com.amplitude.experiment.util.Logger
 import com.amplitude.experiment.util.Once
 import com.amplitude.experiment.util.daemonFactory
 import com.amplitude.experiment.util.getAllCohortIds
-import com.amplitude.experiment.util.wrapMetrics
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
@@ -26,6 +23,8 @@ private const val MIN_COHORT_POLLING_INTERVAL = 60000L
 internal class DeploymentRunner(
     private val config: LocalEvaluationConfig,
     private val flagConfigApi: FlagConfigApi,
+    private val flagConfigProxyApi: FlagConfigApi? = null,
+    private val flagConfigStreamApi: FlagConfigStreamApi? = null,
     private val flagConfigStorage: FlagConfigStorage,
     cohortApi: CohortApi?,
     private val cohortStorage: CohortStorage?,
@@ -39,21 +38,26 @@ internal class DeploymentRunner(
         null
     }
     private val cohortPollingInterval: Long = getCohortPollingInterval()
+    // Fallback in this order: proxy, stream, poll.
+    private val amplitudeFlagConfigPoller = FlagConfigPoller(flagConfigApi, flagConfigStorage, cohortLoader, cohortStorage, config, metrics)
+    private val amplitudeFlagConfigUpdater =
+        if (flagConfigStreamApi != null)
+            FlagConfigFallbackRetryWrapper(
+                FlagConfigStreamer(flagConfigStreamApi, flagConfigStorage, cohortLoader, cohortStorage, config, metrics),
+                amplitudeFlagConfigPoller,
+            )
+        else amplitudeFlagConfigPoller
+    private val flagConfigUpdater =
+        if (flagConfigProxyApi != null)
+            FlagConfigFallbackRetryWrapper(
+                FlagConfigPoller(flagConfigProxyApi, flagConfigStorage, cohortLoader, cohortStorage, config, metrics),
+                amplitudeFlagConfigPoller
+            )
+        else
+            amplitudeFlagConfigUpdater
 
     fun start() = lock.once {
-        refresh()
-        poller.scheduleWithFixedDelay(
-            {
-                try {
-                    refresh()
-                } catch (t: Throwable) {
-                    Logger.e("Refresh flag configs failed.", t)
-                }
-            },
-            config.flagConfigPollerIntervalMillis,
-            config.flagConfigPollerIntervalMillis,
-            TimeUnit.MILLISECONDS
-        )
+        flagConfigUpdater.start()
         if (cohortLoader != null) {
             poller.scheduleWithFixedDelay(
                 {
@@ -74,63 +78,7 @@ internal class DeploymentRunner(
 
     fun stop() {
         poller.shutdown()
-    }
-
-    fun refresh() {
-        Logger.d("Refreshing flag configs.")
-        // Get updated flags from the network.
-        val flagConfigs = wrapMetrics(
-            metric = metrics::onFlagConfigFetch,
-            failure = metrics::onFlagConfigFetchFailure,
-        ) {
-            flagConfigApi.getFlagConfigs()
-        }
-
-        // Remove flags that no longer exist.
-        val flagKeys = flagConfigs.map { it.key }.toSet()
-        flagConfigStorage.removeIf { !flagKeys.contains(it.key) }
-
-        // Get all flags from storage
-        val storageFlags = flagConfigStorage.getFlagConfigs()
-
-        // Load cohorts for each flag if applicable and put the flag in storage.
-        val futures = ConcurrentHashMap<String, CompletableFuture<*>>()
-        for (flagConfig in flagConfigs) {
-            if (cohortLoader == null) {
-                flagConfigStorage.putFlagConfig(flagConfig)
-                continue
-            }
-            val cohortIds = flagConfig.getAllCohortIds()
-            val storageCohortIds = storageFlags[flagConfig.key]?.getAllCohortIds() ?: emptySet()
-            val cohortsToLoad = cohortIds - storageCohortIds
-            if (cohortsToLoad.isEmpty()) {
-                flagConfigStorage.putFlagConfig(flagConfig)
-                continue
-            }
-            for (cohortId in cohortsToLoad) {
-                futures.putIfAbsent(
-                    cohortId,
-                    cohortLoader.loadCohort(cohortId).handle { _, exception ->
-                        if (exception != null) {
-                            Logger.e("Failed to load cohort $cohortId", exception)
-                        }
-                        flagConfigStorage.putFlagConfig(flagConfig)
-                    }
-                )
-            }
-        }
-        futures.values.forEach { it.join() }
-
-        // Delete unused cohorts
-        if (cohortStorage != null) {
-            val flagCohortIds = flagConfigStorage.getFlagConfigs().values.toList().getAllCohortIds()
-            val storageCohortIds = cohortStorage.getCohorts().keys
-            val deletedCohortIds = storageCohortIds - flagCohortIds
-            for (deletedCohortId in deletedCohortIds) {
-                cohortStorage.deleteCohort(deletedCohortId)
-            }
-        }
-        Logger.d("Refreshed ${flagConfigs.size} flag configs.")
+        flagConfigUpdater.shutdown()
     }
 
     private fun getCohortPollingInterval(): Long {

--- a/src/main/kotlin/flag/FlagConfigStreamApi.kt
+++ b/src/main/kotlin/flag/FlagConfigStreamApi.kt
@@ -14,6 +14,8 @@ import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 internal open class FlagConfigStreamApiError(message: String?, cause: Throwable?): Exception(message, cause) {
     constructor(message: String?) : this(message, null)
@@ -32,8 +34,9 @@ internal class FlagConfigStreamApi (
     httpClient: OkHttpClient = OkHttpClient(),
     val connectionTimeoutMillis: Long = CONNECTION_TIMEOUT_MILLIS_DEFAULT,
     keepaliveTimeoutMillis: Long = KEEP_ALIVE_TIMEOUT_MILLIS_DEFAULT,
-    reconnIntervalMillis: Long = RECONN_INTERVAL_MILLIS_DEFAULT
+    reconnIntervalMillis: Long = RECONN_INTERVAL_MILLIS_DEFAULT,
 ) {
+    private val lock: ReentrantLock = ReentrantLock()
     var onInitUpdate: ((List<EvaluationFlag>) -> Unit)? = null
     var onUpdate: ((List<EvaluationFlag>) -> Unit)? = null
     var onError: ((Exception?) -> Unit)? = null
@@ -47,84 +50,88 @@ internal class FlagConfigStreamApi (
         reconnIntervalMillis)
 
     internal fun connect() {
-        val isInit = AtomicBoolean(true)
-        val connectTimeoutFuture = CompletableFuture<Unit>()
-        val updateTimeoutFuture = CompletableFuture<Unit>()
-        stream.onUpdate = { data ->
-            if (isInit.getAndSet(false)) {
-                // Stream is establishing. First data received.
-                // Resolve timeout.
-                connectTimeoutFuture.complete(Unit)
+        // Guarded by lock. Update to callbacks and waits can lead to race conditions.
+        lock.withLock {
+            val isInit = AtomicBoolean(true)
+            val connectTimeoutFuture = CompletableFuture<Unit>()
+            val updateTimeoutFuture = CompletableFuture<Unit>()
+            stream.onUpdate = { data ->
+                if (isInit.getAndSet(false)) {
+                    // Stream is establishing. First data received.
+                    // Resolve timeout.
+                    connectTimeoutFuture.complete(Unit)
 
-                // Make sure valid data.
-                try {
-                    val flags = getFlagsFromData(data)
-
+                    // Make sure valid data.
                     try {
-                        if (onInitUpdate != null) {
-                            onInitUpdate?.let { it(flags) }
-                        } else {
-                            onUpdate?.let { it(flags) }
+                        val flags = getFlagsFromData(data)
+
+                        try {
+                            if (onInitUpdate != null) {
+                                onInitUpdate?.let { it(flags) }
+                            } else {
+                                onUpdate?.let { it(flags) }
+                            }
+                            updateTimeoutFuture.complete(Unit)
+                        } catch (e: Throwable) {
+                            updateTimeoutFuture.completeExceptionally(e)
                         }
-                        updateTimeoutFuture.complete(Unit)
-                    } catch (e: Throwable) {
-                        updateTimeoutFuture.completeExceptionally(e)
-                    }
-                } catch (_: Throwable) {
-                    updateTimeoutFuture.completeExceptionally(FlagConfigStreamApiDataCorruptError())
-                }
-
-            } else {
-                // Stream has already established.
-                // Make sure valid data.
-                try {
-                    val flags = getFlagsFromData(data)
-
-                    try {
-                        onUpdate?.let { it(flags) }
                     } catch (_: Throwable) {
-                        // Don't care about application error.
+                        updateTimeoutFuture.completeExceptionally(FlagConfigStreamApiDataCorruptError())
                     }
-                } catch (_: Throwable) {
-                    // Stream corrupted. Reconnect.
-                    handleError(FlagConfigStreamApiDataCorruptError())
+
+                } else {
+                    // Stream has already established.
+                    // Make sure valid data.
+                    try {
+                        val flags = getFlagsFromData(data)
+
+                        try {
+                            onUpdate?.let { it(flags) }
+                        } catch (_: Throwable) {
+                            // Don't care about application error.
+                        }
+                    } catch (_: Throwable) {
+                        // Stream corrupted. Reconnect.
+                        handleError(FlagConfigStreamApiDataCorruptError())
+                    }
+
                 }
+            }
+            stream.onError = { t ->
+                if (isInit.getAndSet(false)) {
+                    connectTimeoutFuture.completeExceptionally(t)
+                    updateTimeoutFuture.completeExceptionally(t)
+                } else {
+                    handleError(FlagConfigStreamApiStreamError(t))
+                }
+            }
+            stream.connect()
 
+            val t: Throwable
+            try {
+                connectTimeoutFuture.get(connectionTimeoutMillis, TimeUnit.MILLISECONDS)
+                updateTimeoutFuture.get()
+                return
+            } catch (e: TimeoutException) {
+                // Timeouts should retry
+                t = FlagConfigStreamApiConnTimeoutError()
+            } catch (e: ExecutionException) {
+                val cause = e.cause
+                t = if (cause is StreamException) {
+                    FlagConfigStreamApiStreamError(cause)
+                } else {
+                    FlagConfigStreamApiError(e)
+                }
+            } catch (e: Throwable) {
+                t = FlagConfigStreamApiError(e)
             }
+            close()
+            throw t
         }
-        stream.onError = { t ->
-            if (isInit.getAndSet(false)) {
-                connectTimeoutFuture.completeExceptionally(t)
-                updateTimeoutFuture.completeExceptionally(t)
-            } else {
-                handleError(FlagConfigStreamApiStreamError(t))
-            }
-        }
-        stream.connect()
-
-        val t: Throwable
-        try {
-            connectTimeoutFuture.get(connectionTimeoutMillis, TimeUnit.MILLISECONDS)
-            updateTimeoutFuture.get()
-            return
-        } catch (e: TimeoutException) {
-            // Timeouts should retry
-            t = FlagConfigStreamApiConnTimeoutError()
-        } catch (e: ExecutionException) {
-            val cause = e.cause
-            t = if (cause is StreamException) {
-                FlagConfigStreamApiStreamError(cause)
-            } else {
-                FlagConfigStreamApiError(e)
-            }
-        } catch (e: Throwable) {
-            t = FlagConfigStreamApiError(e)
-        }
-        close()
-        throw t
     }
 
     internal fun close() {
+        // Not guarded by lock. close() can halt connect().
         stream.cancel()
     }
 

--- a/src/main/kotlin/flag/FlagConfigStreamApi.kt
+++ b/src/main/kotlin/flag/FlagConfigStreamApi.kt
@@ -46,7 +46,7 @@ internal class FlagConfigStreamApi (
         keepaliveTimeoutMillis,
         reconnIntervalMillis)
 
-    fun connect() {
+    internal fun connect() {
         val isInit = AtomicBoolean(true)
         val connectTimeoutFuture = CompletableFuture<Unit>()
         val updateTimeoutFuture = CompletableFuture<Unit>()
@@ -124,7 +124,7 @@ internal class FlagConfigStreamApi (
         throw t
     }
 
-    fun close() {
+    internal fun close() {
         stream.cancel()
     }
 

--- a/src/main/kotlin/flag/FlagConfigStreamApi.kt
+++ b/src/main/kotlin/flag/FlagConfigStreamApi.kt
@@ -6,6 +6,9 @@ import com.amplitude.experiment.util.SseStream
 import kotlinx.serialization.decodeFromString
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.sse.EventSource
+import okhttp3.sse.EventSourceListener
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
@@ -27,7 +30,7 @@ internal class FlagConfigStreamApi (
     deploymentKey: String,
     serverUrl: HttpUrl,
     httpClient: OkHttpClient = OkHttpClient(),
-    connectionTimeoutMillis: Long = CONNECTION_TIMEOUT_MILLIS_DEFAULT,
+    val connectionTimeoutMillis: Long = CONNECTION_TIMEOUT_MILLIS_DEFAULT,
     keepaliveTimeoutMillis: Long = KEEP_ALIVE_TIMEOUT_MILLIS_DEFAULT,
     reconnIntervalMillis: Long = RECONN_INTERVAL_MILLIS_DEFAULT
 ) {
@@ -101,7 +104,7 @@ internal class FlagConfigStreamApi (
 
         val t: Throwable
         try {
-            connectTimeoutFuture.get(2000, TimeUnit.MILLISECONDS)
+            connectTimeoutFuture.get(connectionTimeoutMillis, TimeUnit.MILLISECONDS)
             updateTimeoutFuture.get()
             return
         } catch (e: TimeoutException) {

--- a/src/main/kotlin/flag/FlagConfigStreamApi.kt
+++ b/src/main/kotlin/flag/FlagConfigStreamApi.kt
@@ -15,18 +15,18 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
-internal open class FlagConfigStreamApiError(message: String?, cause: Throwable?): Exception(message, cause) {
+internal open class FlagConfigStreamApiError(message: String?, cause: Throwable?) : Exception(message, cause) {
     constructor(message: String?) : this(message, null)
     constructor(cause: Throwable?) : this(cause?.toString(), cause)
 }
-internal class FlagConfigStreamApiConnTimeoutError: FlagConfigStreamApiError("Initial connection timed out")
-internal class FlagConfigStreamApiDataCorruptError: FlagConfigStreamApiError("Stream data corrupted")
-internal class FlagConfigStreamApiStreamError(cause: Throwable?): FlagConfigStreamApiError("Stream error", cause)
+internal class FlagConfigStreamApiConnTimeoutError : FlagConfigStreamApiError("Initial connection timed out")
+internal class FlagConfigStreamApiDataCorruptError : FlagConfigStreamApiError("Stream data corrupted")
+internal class FlagConfigStreamApiStreamError(cause: Throwable?) : FlagConfigStreamApiError("Stream error", cause)
 
 private const val CONNECTION_TIMEOUT_MILLIS_DEFAULT = 1500L
 private const val KEEP_ALIVE_TIMEOUT_MILLIS_DEFAULT = 17000L // keep alive sends at 15s interval. 2s grace period
 private const val RECONN_INTERVAL_MILLIS_DEFAULT = 15 * 60 * 1000L
-internal class FlagConfigStreamApi (
+internal class FlagConfigStreamApi(
     deploymentKey: String,
     serverUrl: HttpUrl,
     httpClient: OkHttpClient = OkHttpClient(),
@@ -42,7 +42,8 @@ internal class FlagConfigStreamApi (
         httpClient,
         connectionTimeoutMillis,
         keepaliveTimeoutMillis,
-        reconnIntervalMillis)
+        reconnIntervalMillis
+    )
 
     /**
      * Connects to flag configs stream.
@@ -82,7 +83,6 @@ internal class FlagConfigStreamApi (
                     } catch (_: Throwable) {
                         updateTimeoutFuture.completeExceptionally(FlagConfigStreamApiDataCorruptError())
                     }
-
                 } else {
                     // Stream has already established.
                     // Make sure valid data.
@@ -98,7 +98,6 @@ internal class FlagConfigStreamApi (
                         // Stream corrupted. Reconnect.
                         handleError(onError, FlagConfigStreamApiDataCorruptError())
                     }
-
                 }
             }
             val onSseError: ((Throwable?) -> Unit) = { t ->

--- a/src/main/kotlin/flag/FlagConfigUpdater.kt
+++ b/src/main/kotlin/flag/FlagConfigUpdater.kt
@@ -1,0 +1,233 @@
+package com.amplitude.experiment.flag
+
+import com.amplitude.experiment.LocalEvaluationConfig
+import com.amplitude.experiment.LocalEvaluationMetrics
+import com.amplitude.experiment.cohort.CohortLoader
+import com.amplitude.experiment.cohort.CohortStorage
+import com.amplitude.experiment.evaluation.EvaluationFlag
+import com.amplitude.experiment.util.*
+import com.amplitude.experiment.util.Logger
+import com.amplitude.experiment.util.daemonFactory
+import com.amplitude.experiment.util.wrapMetrics
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+internal interface FlagConfigUpdater {
+    // Start the updater. There can be multiple calls.
+    // If start fails, it should throw exception. The caller should handle fallback.
+    // If some other error happened while updating (already started successfully), it should call fallback.
+    fun start(fallback: (() -> Unit)? = null)
+    // Stop should stop updater temporarily. There may be another start in the future.
+    // To stop completely, with intention to never start again, use shutdown() instead.
+    fun stop()
+    // Destroy should stop the updater forever in preparation for server shutdown.
+    fun shutdown()
+}
+
+internal abstract class FlagConfigUpdaterBase(
+    private val flagConfigStorage: FlagConfigStorage,
+    private val cohortLoader: CohortLoader?,
+    private val cohortStorage: CohortStorage?,
+): FlagConfigUpdater {
+    fun update(flagConfigs: List<EvaluationFlag>) {
+        println("update")
+        // Remove flags that no longer exist.
+        val flagKeys = flagConfigs.map { it.key }.toSet()
+        flagConfigStorage.removeIf { !flagKeys.contains(it.key) }
+
+        // Get all flags from storage
+        val storageFlags = flagConfigStorage.getFlagConfigs()
+
+        // Load cohorts for each flag if applicable and put the flag in storage.
+        val futures = ConcurrentHashMap<String, CompletableFuture<*>>()
+        for (flagConfig in flagConfigs) {
+            if (cohortLoader == null) {
+                flagConfigStorage.putFlagConfig(flagConfig)
+                continue
+            }
+            val cohortIds = flagConfig.getAllCohortIds()
+            val storageCohortIds = storageFlags[flagConfig.key]?.getAllCohortIds() ?: emptySet()
+            val cohortsToLoad = cohortIds - storageCohortIds
+            if (cohortsToLoad.isEmpty()) {
+                flagConfigStorage.putFlagConfig(flagConfig)
+                continue
+            }
+            for (cohortId in cohortsToLoad) {
+                futures.putIfAbsent(
+                    cohortId,
+                    cohortLoader.loadCohort(cohortId).handle { _, exception ->
+                        if (exception != null) {
+                            Logger.e("Failed to load cohort $cohortId", exception)
+                        }
+                        flagConfigStorage.putFlagConfig(flagConfig)
+                    }
+                )
+            }
+        }
+        futures.values.forEach { it.join() }
+
+        // Delete unused cohorts
+        if (cohortStorage != null) {
+            val flagCohortIds = flagConfigStorage.getFlagConfigs().values.toList().getAllCohortIds()
+            val storageCohortIds = cohortStorage.getCohorts().keys
+            val deletedCohortIds = storageCohortIds - flagCohortIds
+            for (deletedCohortId in deletedCohortIds) {
+                cohortStorage.deleteCohort(deletedCohortId)
+            }
+        }
+        Logger.d("Refreshed ${flagConfigs.size} flag configs.")
+    }
+}
+
+internal class FlagConfigPoller(
+    private val flagConfigApi: FlagConfigApi,
+    private val storage: FlagConfigStorage,
+    private val cohortLoader: CohortLoader?,
+    private val cohortStorage: CohortStorage?,
+    private val config: LocalEvaluationConfig,
+    private val metrics: LocalEvaluationMetrics = LocalEvaluationMetricsWrapper()
+): FlagConfigUpdaterBase(
+    storage, cohortLoader, cohortStorage
+) {
+    private val poller = Executors.newScheduledThreadPool(1, daemonFactory)
+    private var scheduledFuture: ScheduledFuture<*>? = null
+    override fun start(fallback: (() -> Unit)?) {
+        // Perform updates
+        refresh()
+        scheduledFuture = poller.scheduleWithFixedDelay(
+            {
+                try {
+                    refresh()
+                } catch (t: Throwable) {
+                    Logger.e("Refresh flag configs failed.", t)
+                    stop()
+                    fallback?.invoke()
+                }
+            },
+            config.flagConfigPollerIntervalMillis,
+            config.flagConfigPollerIntervalMillis,
+            TimeUnit.MILLISECONDS
+        )
+    }
+
+    override fun stop() {
+        // Pause only stop the task scheduled. It doesn't stop the executor.
+        scheduledFuture?.cancel(true)
+        scheduledFuture = null
+    }
+
+    override fun shutdown() {
+        // Stop the executor.
+        poller.shutdown()
+    }
+
+    fun refresh() {
+        Logger.d("Refreshing flag configs.")
+        println("flag poller refreshing")
+        // Get updated flags from the network.
+        val flagConfigs = wrapMetrics(
+            metric = metrics::onFlagConfigFetch,
+            failure = metrics::onFlagConfigFetchFailure,
+        ) {
+            flagConfigApi.getFlagConfigs()
+        }
+
+        update(flagConfigs)
+        println("flag poller refreshed")
+    }
+}
+
+internal class FlagConfigStreamer(
+    private val flagConfigStreamApi: FlagConfigStreamApi,
+    private val storage: FlagConfigStorage,
+    private val cohortLoader: CohortLoader?,
+    private val cohortStorage: CohortStorage?,
+    private val config: LocalEvaluationConfig,
+    private val metrics: LocalEvaluationMetrics = LocalEvaluationMetricsWrapper()
+): FlagConfigUpdaterBase(
+    storage, cohortLoader, cohortStorage
+) {
+    override fun start(fallback: (() -> Unit)?) {
+        flagConfigStreamApi.onUpdate = {flags ->
+            println("flag streamer received")
+            update(flags)
+        }
+        flagConfigStreamApi.onError = {e ->
+            Logger.e("Stream flag configs streaming failed.", e)
+            metrics.onFlagConfigStreamFailure(e)
+            fallback?.invoke()
+        }
+        wrapMetrics(metric = metrics::onFlagConfigStream, failure = metrics::onFlagConfigStreamFailure) {
+            flagConfigStreamApi.connect()
+        }
+    }
+
+    override fun stop() {
+        flagConfigStreamApi.close()
+    }
+
+    override fun shutdown() = stop()
+}
+
+private const val RETRY_DELAY_MILLIS_DEFAULT = 15 * 1000L
+private const val MAX_JITTER_MILLIS_DEFAULT = 2000L
+internal class FlagConfigFallbackRetryWrapper(
+    private val mainUpdater: FlagConfigUpdater,
+    private val fallbackUpdater: FlagConfigUpdater,
+    private val retryDelayMillis: Long = RETRY_DELAY_MILLIS_DEFAULT,
+    private val maxJitterMillis: Long = MAX_JITTER_MILLIS_DEFAULT
+): FlagConfigUpdater {
+    private val reconnIntervalRange = (retryDelayMillis - maxJitterMillis)..(retryDelayMillis + maxJitterMillis)
+    private val executor = Executors.newScheduledThreadPool(1, daemonFactory)
+    private var retryTask: ScheduledFuture<*>? = null
+
+    override fun start(fallback: (() -> Unit)?) {
+        try {
+            mainUpdater.start {
+                startRetry(fallback) // Don't care if poller start error or not, always retry.
+                try {
+                    fallbackUpdater.start(fallback)
+                } catch (_: Throwable) {
+                    fallback?.invoke()
+                }
+            }
+        } catch (t: Throwable) {
+            Logger.e("Update flag configs start failed.", t)
+            fallbackUpdater.start(fallback) // If fallback failed, don't retry.
+            startRetry(fallback)
+        }
+    }
+
+    override fun stop() {
+        mainUpdater.stop()
+        fallbackUpdater.stop()
+        retryTask?.cancel(true)
+    }
+
+    override fun shutdown() {
+        mainUpdater.shutdown()
+        fallbackUpdater.shutdown()
+        retryTask?.cancel(true)
+    }
+
+    private fun startRetry(fallback: (() -> Unit)?) {
+        retryTask = executor.schedule({
+            try {
+                mainUpdater.start {
+                    startRetry(fallback) // Don't care if poller start error or not, always retry stream.
+                    try {
+                        fallbackUpdater.start(fallback)
+                    } catch (_: Throwable) {
+                        fallback?.invoke()
+                    }
+                }
+                fallbackUpdater.stop()
+            } catch (_: Throwable) {
+                startRetry(fallback)
+            }
+        }, reconnIntervalRange.random(), TimeUnit.MILLISECONDS)
+    }
+}

--- a/src/main/kotlin/flag/FlagConfigUpdater.kt
+++ b/src/main/kotlin/flag/FlagConfigUpdater.kt
@@ -117,7 +117,7 @@ internal class FlagConfigPoller(
     cohortStorage: CohortStorage?,
     private val config: LocalEvaluationConfig,
     private val metrics: LocalEvaluationMetrics = LocalEvaluationMetricsWrapper(),
-): FlagConfigUpdater, FlagConfigUpdaterBase(
+) : FlagConfigUpdater, FlagConfigUpdaterBase(
     storage, cohortLoader, cohortStorage
 ) {
     private val lock: ReentrantLock = ReentrantLock()
@@ -191,7 +191,7 @@ internal class FlagConfigStreamer(
     cohortLoader: CohortLoader?,
     cohortStorage: CohortStorage?,
     private val metrics: LocalEvaluationMetrics = LocalEvaluationMetricsWrapper()
-): FlagConfigUpdater, FlagConfigUpdaterBase(
+) : FlagConfigUpdater, FlagConfigUpdaterBase(
     storage, cohortLoader, cohortStorage
 ) {
     private val lock: ReentrantLock = ReentrantLock()
@@ -240,7 +240,7 @@ internal class FlagConfigFallbackRetryWrapper(
     private val fallbackUpdater: FlagConfigUpdater?,
     retryDelayMillis: Long = RETRY_DELAY_MILLIS_DEFAULT,
     maxJitterMillis: Long = MAX_JITTER_MILLIS_DEFAULT,
-): FlagConfigUpdater {
+) : FlagConfigUpdater {
     private val lock: ReentrantLock = ReentrantLock()
     private val reconnIntervalRange = max(0, retryDelayMillis - maxJitterMillis)..(min(retryDelayMillis, Long.MAX_VALUE - maxJitterMillis) + maxJitterMillis)
     private val executor = Executors.newScheduledThreadPool(1, daemonFactory)
@@ -320,5 +320,6 @@ internal class FlagConfigFallbackRetryWrapper(
                 scheduleRetry()
             }
         }, reconnIntervalRange.random(), TimeUnit.MILLISECONDS)
+        }
     }
-}
+    

--- a/src/main/kotlin/flag/FlagConfigUpdater.kt
+++ b/src/main/kotlin/flag/FlagConfigUpdater.kt
@@ -199,7 +199,11 @@ internal class FlagConfigFallbackRetryWrapper(
             }
         } catch (t: Throwable) {
             Logger.e("Primary flag configs start failed, start fallback. Error: ", t)
-            fallbackUpdater?.start()
+            if (fallbackUpdater == null) {
+                // No fallback, main start failed is wrapper start fail
+                throw t
+            }
+            fallbackUpdater.start()
             scheduleRetry()
         }
     }

--- a/src/main/kotlin/util/Metrics.kt
+++ b/src/main/kotlin/util/Metrics.kt
@@ -66,6 +66,16 @@ internal class LocalEvaluationMetricsWrapper(
         executor?.execute { metrics.onFlagConfigFetchFailure(exception) }
     }
 
+    override fun onFlagConfigStream() {
+        val metrics = metrics ?: return
+        executor?.execute { metrics.onFlagConfigStream() }
+    }
+
+    override fun onFlagConfigStreamFailure(exception: Exception?) {
+        val metrics = metrics ?: return
+        executor?.execute { metrics.onFlagConfigStreamFailure(exception) }
+    }
+
     override fun onFlagConfigFetchOriginFallback(exception: Exception) {
         val metrics = metrics ?: return
         executor?.execute { metrics.onFlagConfigFetchOriginFallback(exception) }

--- a/src/main/kotlin/util/Request.kt
+++ b/src/main/kotlin/util/Request.kt
@@ -60,7 +60,7 @@ private fun OkHttpClient.submit(
     return future
 }
 
-private fun newGet(
+internal fun newGet(
     serverUrl: HttpUrl,
     path: String? = null,
     headers: Map<String, String>? = null,

--- a/src/main/kotlin/util/Request.kt
+++ b/src/main/kotlin/util/Request.kt
@@ -8,6 +8,9 @@ import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import okhttp3.sse.EventSource
+import okhttp3.sse.EventSourceListener
+import okhttp3.sse.EventSources
 import okio.IOException
 import java.util.concurrent.CompletableFuture
 
@@ -110,4 +113,9 @@ internal inline fun <reified T> OkHttpClient.get(
             throw HttpErrorResponseException(response.code)
         }
     }
+}
+
+internal fun OkHttpClient.newEventSource(request: Request, eventSourceListener: EventSourceListener): EventSource {
+    // Creates an event source and immediately returns it. The connection is performed async.
+    return EventSources.createFactory(this).newEventSource(request, eventSourceListener)
 }

--- a/src/main/kotlin/util/SdkStream.kt
+++ b/src/main/kotlin/util/SdkStream.kt
@@ -1,0 +1,122 @@
+package com.amplitude.experiment.util
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.internal.http2.ErrorCode
+import okhttp3.internal.http2.StreamResetException
+import okhttp3.sse.EventSource
+import okhttp3.sse.EventSourceListener
+import okhttp3.sse.EventSources
+import java.util.*
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.schedule
+
+internal class StreamException(error: String): Throwable(error)
+
+private const val RECONN_INTERVAL_MILLIS_DEFAULT = 30 * 60 * 1000L
+private const val MAX_JITTER_MILLIS_DEFAULT = 5000L
+internal class SdkStream (
+    private val authToken: String,
+    private val serverUrl: String,
+    private val httpClient: OkHttpClient = OkHttpClient(),
+    private val connectionTimeoutMillis: Long,
+    private val keepaliveTimeoutMillis: Long,
+    private val reconnIntervalMillis: Long = RECONN_INTERVAL_MILLIS_DEFAULT,
+    private val maxJitterMillis: Long = MAX_JITTER_MILLIS_DEFAULT
+) {
+    private val reconnIntervalRange = (reconnIntervalMillis - maxJitterMillis)..(reconnIntervalMillis + maxJitterMillis)
+    private val eventSourceListener = object : EventSourceListener() {
+        override fun onOpen(eventSource: EventSource, response: Response) {
+            // No action needed.
+        }
+
+        override fun onClosed(eventSource: EventSource) {
+            if ((eventSource != es)) {
+                // Not the current event source using right now, should cancel.
+                eventSource.cancel()
+                return
+            }
+            // Server closed the connection, just reconnect.
+            cancel()
+            connect()
+        }
+
+        override fun onEvent(
+            eventSource: EventSource,
+            id: String?,
+            type: String?,
+            data: String
+        ) {
+            if ((eventSource != es)) {
+                // Not the current event source using right now, should cancel.
+                eventSource.cancel()
+                return
+            }
+            // Keep alive data
+            if (" " == data) {
+                return
+            }
+            onUpdate?.let { it(data) }
+        }
+
+        override fun onFailure(eventSource: EventSource, t: Throwable?, response: Response?) {
+            if ((eventSource != es)) {
+                // Not the current event source using right now, should cancel.
+                eventSource.cancel()
+                return
+            }
+            if (t is StreamResetException && t.errorCode == ErrorCode.CANCEL) {
+                // TODO: relying on okhttp3.internal to differentiate cancel case.
+                return
+            }
+            cancel()
+            var err = t
+            if (t == null) {
+                err = if (response != null) {
+                    StreamException(response.toString())
+                } else {
+                    StreamException("Unknown stream failure")
+                }
+            }
+            onError?.let { it(err) }
+        }
+    }
+
+    private val request = Request.Builder()
+        .url(serverUrl)
+        .header("Authorization", authToken)
+        .addHeader("Accept", "text/event-stream")
+        .build()
+
+    private val client = httpClient.newBuilder() // client.newBuilder reuses the connection pool in the same client with new configs.
+        .connectTimeout(connectionTimeoutMillis, TimeUnit.MILLISECONDS) // Connection timeout for establishing SSE.
+        .callTimeout(connectionTimeoutMillis, TimeUnit.MILLISECONDS) // Call timeout for establishing SSE.
+        .readTimeout(keepaliveTimeoutMillis, TimeUnit.MILLISECONDS) // Timeout between messages, keepalive in this case.
+        .writeTimeout(connectionTimeoutMillis, TimeUnit.MILLISECONDS)
+        .retryOnConnectionFailure(false)
+        .build()
+
+    private var es: EventSource? = null
+    private var reconnectTimerTask: TimerTask? = null
+    var onUpdate: ((String) -> Unit)? = null
+    var onError: ((Throwable?) -> Unit)? = null
+
+    fun connect() {
+        cancel() // Clear any existing event sources.
+        es = EventSources.createFactory(client).newEventSource(request = request, listener = eventSourceListener)
+        reconnectTimerTask = Timer().schedule(reconnIntervalRange.random()) {// Timer for a new event source.
+            // This forces client side reconnection after interval.
+            this@SdkStream.cancel()
+            connect()
+        }
+    }
+
+    fun cancel() {
+        reconnectTimerTask?.cancel()
+
+        // There can be cases where an event source is being cancelled by these calls, but take a long time and made a callback to onFailure callback.
+        es?.cancel()
+        es = null
+    }
+}

--- a/src/main/kotlin/util/SseStream.kt
+++ b/src/main/kotlin/util/SseStream.kt
@@ -68,8 +68,6 @@ internal class SseStream (
         }
 
         override fun onFailure(eventSource: EventSource, t: Throwable?, response: Response?) {
-            println(t)
-            println(response)
             if ((eventSource != es)) {
                 // Not the current event source using right now, should cancel.
                 eventSource.cancel()

--- a/src/main/kotlin/util/SseStream.kt
+++ b/src/main/kotlin/util/SseStream.kt
@@ -1,17 +1,14 @@
 package com.amplitude.experiment.util
 
-import com.amplitude.experiment.LIBRARY_VERSION
 import okhttp3.HttpUrl
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
-import okhttp3.Request
 import okhttp3.Response
 import okhttp3.internal.http2.ErrorCode
 import okhttp3.internal.http2.StreamResetException
 import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
-import okhttp3.sse.EventSources
-import java.util.*
+import java.util.Timer
+import java.util.TimerTask
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.schedule
@@ -25,81 +22,23 @@ private const val KEEP_ALIVE_TIMEOUT_MILLIS_DEFAULT = 0L // no timeout
 private const val RECONN_INTERVAL_MILLIS_DEFAULT = 30 * 60 * 1000L
 private const val MAX_JITTER_MILLIS_DEFAULT = 5000L
 private const val KEEP_ALIVE_DATA = " "
+
+/**
+ * For establishing an SSE stream.
+ */
 internal class SseStream (
-    private val authToken: String,
-    private val url: HttpUrl,
-    private val httpClient: OkHttpClient = OkHttpClient(),
-    private val connectionTimeoutMillis: Long,
-    private val keepaliveTimeoutMillis: Long = KEEP_ALIVE_TIMEOUT_MILLIS_DEFAULT,
-    private val reconnIntervalMillis: Long = RECONN_INTERVAL_MILLIS_DEFAULT,
-    private val maxJitterMillis: Long = MAX_JITTER_MILLIS_DEFAULT,
+    authToken: String, // Will be used in header as Authorization: <authToken>
+    url: HttpUrl, // The full url to connect to.
+    httpClient: OkHttpClient = OkHttpClient(),
+    connectionTimeoutMillis: Long, // Timeout for establishing a connection, not including reading body.
+    keepaliveTimeoutMillis: Long = KEEP_ALIVE_TIMEOUT_MILLIS_DEFAULT, // Keep alive should receive within this timeout.
+    reconnIntervalMillis: Long = RECONN_INTERVAL_MILLIS_DEFAULT, // Reconnect every this interval.
+    maxJitterMillis: Long = MAX_JITTER_MILLIS_DEFAULT, // Jitter for reconnection.
 ) {
     private val lock: ReentrantLock = ReentrantLock()
     private val reconnIntervalRange = max(0, reconnIntervalMillis - maxJitterMillis)..(min(reconnIntervalMillis, Long.MAX_VALUE - maxJitterMillis) + maxJitterMillis)
-    private val eventSourceListener = object : EventSourceListener() {
-        override fun onOpen(eventSource: EventSource, response: Response) {
-            // No action needed.
-        }
-
-        override fun onClosed(eventSource: EventSource) {
-            lock.withLock {
-                if ((eventSource != es)) {
-                    // Not the current event source using right now, should cancel.
-                    eventSource.cancel()
-                    return
-                }
-            }
-            // Server closed the connection, just reconnect.
-            cancelInternal()
-            connect()
-        }
-
-        override fun onEvent(
-            eventSource: EventSource,
-            id: String?,
-            type: String?,
-            data: String
-        ) {
-            lock.withLock {
-                if ((eventSource != es)) {
-                    // Not the current event source using right now, should cancel.
-                    eventSource.cancel()
-                    return
-                }
-            }
-            // Keep alive data
-            if (KEEP_ALIVE_DATA == data) {
-                return
-            }
-            onUpdate?.let { it(data) }
-        }
-
-        override fun onFailure(eventSource: EventSource, t: Throwable?, response: Response?) {
-            lock.withLock {
-                if ((eventSource != es)) {
-                    // Not the current event source using right now, should cancel.
-                    eventSource.cancel()
-                    return
-                }
-            }
-            if (t is StreamResetException && t.errorCode == ErrorCode.CANCEL) {
-                // Relying on okhttp3.internal to differentiate cancel case.
-                // Can be a pitfall later on.
-                return
-            }
-            cancel()
-            val err = t
-                ?: if (response != null) {
-                    StreamException(response.toString())
-                } else {
-                    StreamException("Unknown stream failure")
-                }
-            onError?.let { it(err) }
-        }
-    }
 
     private val request = newGet(url, null, mapOf("Authorization" to authToken, "Accept" to "text/event-stream"))
-
     private val client = httpClient.newBuilder() // client.newBuilder reuses the connection pool in the same client with new configs.
         .connectTimeout(connectionTimeoutMillis, TimeUnit.MILLISECONDS) // Connection timeout for establishing SSE.
         .callTimeout(connectionTimeoutMillis, TimeUnit.MILLISECONDS) // Call timeout for establishing SSE.
@@ -110,26 +49,95 @@ internal class SseStream (
 
     private var es: EventSource? = null // @GuardedBy(lock)
     private var reconnectTimerTask: TimerTask? = null // @GuardedBy(lock)
-    internal var onUpdate: ((String) -> Unit)? = null
-    internal var onError: ((Throwable?) -> Unit)? = null
+    private var onUpdate: ((String) -> Unit)? = null
+    private var onError: ((Throwable?) -> Unit)? = null
+
+    private val eventSourceListener = object : EventSourceListener() {
+        override fun onOpen(eventSource: EventSource, response: Response) {
+            // No action needed.
+        }
+
+        override fun onClosed(eventSource: EventSource) {
+            lock.withLock {
+                if ((eventSource != es)) { // Reference comparison.
+                    // Not the current event source using right now, should cancel.
+                    eventSource.cancel()
+                    return
+                }
+                // Server closed the connection, just reconnect.
+                cancelSse()
+            }
+            connect(onUpdate, onError)
+        }
+
+        override fun onEvent(
+            eventSource: EventSource,
+            id: String?,
+            type: String?,
+            data: String
+        ) {
+            lock.withLock {
+                if ((eventSource != es)) { // Reference comparison.
+                    // Not the current event source using right now, should cancel.
+                    eventSource.cancel()
+                    return
+                }
+            }
+            // Keep alive data
+            if (KEEP_ALIVE_DATA == data) {
+                return
+            }
+            onUpdate?.invoke(data)
+        }
+
+        override fun onFailure(eventSource: EventSource, t: Throwable?, response: Response?) {
+            lock.withLock {
+                if ((eventSource != es)) { // Reference comparison.
+                    // Not the current event source using right now, should cancel.
+                    eventSource.cancel()
+                    return
+                }
+                if (t is StreamResetException && t.errorCode == ErrorCode.CANCEL) {
+                    // Relying on okhttp3.internal to differentiate cancel case.
+                    // Can be a pitfall later on.
+                    return
+                }
+                cancelSse()
+            }
+            val err = t
+                ?: if (response != null) {
+                    StreamException(response.toString())
+                } else {
+                    StreamException("Unknown stream failure")
+                }
+            onError?.invoke(err)
+        }
+    }
 
     /**
-     * Creates an event source and immediately returns. The connection is performed async. Errors are informed through callbacks.
+     * Creates an event source and immediately returns. The connection is performed async. All errors are informed through callbacks.
+     * This the call may success even if stream cannot be established.
+     *
+     * @param onUpdate On stream update, this callback will be called.
+     * @param onError On stream error, this callback will be called.
      */
-    internal fun connect() {
+    internal fun connect(onUpdate: ((String) -> Unit)?, onError: ((Throwable?) -> Unit)?) {
         lock.withLock {
-            cancelInternal() // Clear any existing event sources.
+            cancelSse() // Clear any existing event sources.
+
+            this.onUpdate = onUpdate
+            this.onError = onError
             es = client.newEventSource(request, eventSourceListener)
             reconnectTimerTask = Timer().schedule(reconnIntervalRange.random()) {// Timer for a new event source.
                 // This forces client side reconnection after interval.
                 this@SseStream.cancel()
-                connect()
+                connect(onUpdate, onError)
             }
         }
     }
 
     // @GuardedBy(lock)
-    private fun cancelInternal() {
+    private fun cancelSse() {
         reconnectTimerTask?.cancel()
 
         // There can be cases where an event source is being cancelled by these calls, but take a long time and made a callback to onFailure callback.
@@ -137,9 +145,14 @@ internal class SseStream (
         es = null
     }
 
+    /**
+     * Cancels the current connection.
+     */
     internal fun cancel() {
         lock.withLock {
-            cancelInternal()
+            cancelSse()
+            this.onUpdate = null
+            this.onError = null
         }
     }
 }

--- a/src/main/kotlin/util/SseStream.kt
+++ b/src/main/kotlin/util/SseStream.kt
@@ -101,13 +101,13 @@ internal class SseStream (
 
     private var es: EventSource? = null
     private var reconnectTimerTask: TimerTask? = null
-    var onUpdate: ((String) -> Unit)? = null
-    var onError: ((Throwable?) -> Unit)? = null
+    internal var onUpdate: ((String) -> Unit)? = null
+    internal var onError: ((Throwable?) -> Unit)? = null
 
     /**
      * Creates an event source and immediately returns. The connection is performed async. Errors are informed through callbacks.
      */
-    fun connect() {
+    internal fun connect() {
         cancel() // Clear any existing event sources.
         es = client.newEventSource(request, eventSourceListener)
         reconnectTimerTask = Timer().schedule(reconnIntervalRange.random()) {// Timer for a new event source.
@@ -117,7 +117,7 @@ internal class SseStream (
         }
     }
 
-    fun cancel() {
+    internal fun cancel() {
         reconnectTimerTask?.cancel()
 
         // There can be cases where an event source is being cancelled by these calls, but take a long time and made a callback to onFailure callback.

--- a/src/main/kotlin/util/SseStream.kt
+++ b/src/main/kotlin/util/SseStream.kt
@@ -16,7 +16,7 @@ import kotlin.concurrent.withLock
 import kotlin.math.max
 import kotlin.math.min
 
-internal class StreamException(error: String): Throwable(error)
+internal class StreamException(error: String) : Throwable(error)
 
 private const val KEEP_ALIVE_TIMEOUT_MILLIS_DEFAULT = 0L // no timeout
 private const val RECONN_INTERVAL_MILLIS_DEFAULT = 30 * 60 * 1000L
@@ -26,7 +26,7 @@ private const val KEEP_ALIVE_DATA = " "
 /**
  * For establishing an SSE stream.
  */
-internal class SseStream (
+internal class SseStream(
     authToken: String, // Will be used in header as Authorization: <authToken>
     url: HttpUrl, // The full url to connect to.
     httpClient: OkHttpClient = OkHttpClient(),
@@ -128,7 +128,7 @@ internal class SseStream (
             this.onUpdate = onUpdate
             this.onError = onError
             es = client.newEventSource(request, eventSourceListener)
-            reconnectTimerTask = Timer().schedule(reconnIntervalRange.random()) {// Timer for a new event source.
+            reconnectTimerTask = Timer().schedule(reconnIntervalRange.random()) { // Timer for a new event source.
                 // This forces client side reconnection after interval.
                 this@SseStream.cancel()
                 connect(onUpdate, onError)

--- a/src/test/kotlin/LocalEvaluationClientTest.kt
+++ b/src/test/kotlin/LocalEvaluationClientTest.kt
@@ -12,7 +12,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import kotlin.system.measureNanoTime
 import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 
 private const val API_KEY = "server-qz35UwzJ5akieoAdIgzM4m9MIiOLXLoz"

--- a/src/test/kotlin/deployment/DeploymentRunnerTest.kt
+++ b/src/test/kotlin/deployment/DeploymentRunnerTest.kt
@@ -42,11 +42,11 @@ class DeploymentRunnerTest {
         val flagConfigStorage = Mockito.mock(FlagConfigStorage::class.java)
         val cohortStorage = Mockito.mock(CohortStorage::class.java)
         val runner = DeploymentRunner(
-            LocalEvaluationConfig(),
-            flagApi,
-            flagConfigStorage,
-            cohortApi,
-            cohortStorage,
+            config = LocalEvaluationConfig(),
+            flagConfigApi = flagApi,
+            flagConfigStorage = flagConfigStorage,
+            cohortApi = cohortApi,
+            cohortStorage = cohortStorage,
         )
         Mockito.`when`(flagApi.getFlagConfigs()).thenThrow(RuntimeException("test"))
         try {
@@ -71,10 +71,11 @@ class DeploymentRunnerTest {
         val flagConfigStorage = Mockito.mock(FlagConfigStorage::class.java)
         val cohortStorage = Mockito.mock(CohortStorage::class.java)
         val runner = DeploymentRunner(
-            LocalEvaluationConfig(),
-            flagApi, flagConfigStorage,
-            cohortApi,
-            cohortStorage,
+            config = LocalEvaluationConfig(),
+            flagConfigApi = flagApi,
+            flagConfigStorage = flagConfigStorage,
+            cohortApi = cohortApi,
+            cohortStorage = cohortStorage,
         )
         Mockito.`when`(flagApi.getFlagConfigs()).thenReturn(listOf(flag))
         Mockito.`when`(cohortApi.getCohort(COHORT_ID, null)).thenThrow(RuntimeException("test"))

--- a/src/test/kotlin/flag/FlagConfigStreamApiTest.kt
+++ b/src/test/kotlin/flag/FlagConfigStreamApiTest.kt
@@ -36,10 +36,6 @@ class FlagConfigStreamApiTest {
         }
     }
 
-    private fun <T> anyConstructed(): Any {
-        TODO("Not yet implemented")
-    }
-
     @AfterTest
     fun afterTest() {
         clearAllMocks()

--- a/src/test/kotlin/flag/FlagConfigStreamApiTest.kt
+++ b/src/test/kotlin/flag/FlagConfigStreamApiTest.kt
@@ -1,0 +1,152 @@
+package com.amplitude.experiment.flag
+
+import com.amplitude.experiment.Experiment
+import com.amplitude.experiment.evaluation.EvaluationFlag
+import com.amplitude.experiment.util.SseStream
+import io.mockk.*
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import kotlin.test.*
+
+class FlagConfigStreamApiTest {
+    private val onUpdateCapture = slot<((String) -> Unit)>()
+    private val onErrorCapture = slot<((Throwable?) -> Unit)>()
+
+    private var data: Array<List<EvaluationFlag>> = arrayOf()
+    private var err: Array<Throwable?> = arrayOf()
+
+    @BeforeTest
+    fun beforeTest() {
+        mockkConstructor(SseStream::class)
+
+        every { anyConstructed<SseStream>().connect() } answers {
+            Thread.sleep(1000)
+        }
+        every { anyConstructed<SseStream>().cancel() } answers {
+            Thread.sleep(1000)
+        }
+        every { anyConstructed<SseStream>().onUpdate = capture(onUpdateCapture) } answers {}
+        every { anyConstructed<SseStream>().onError = capture(onErrorCapture) } answers {}
+    }
+
+    private fun setupApi(
+        deploymentKey: String = "",
+        serverUrl: HttpUrl = "http://localhost".toHttpUrl(),
+        connTimeout: Long = 2000
+    ): FlagConfigStreamApi {
+        val api = FlagConfigStreamApi(deploymentKey, serverUrl, OkHttpClient(), connTimeout, 10000)
+
+        api.onUpdate = { d ->
+            data += d
+        }
+        api.onError = { t ->
+            err += t
+        }
+        return api
+    }
+
+    @Test
+    fun `Test passes correct arguments`() {
+        val api = setupApi("deplkey", "https://test.example.com".toHttpUrl())
+        api.onInitUpdate = { d ->
+            data += d
+        }
+
+        val run = async {
+            api.connect()
+        }
+        Thread.sleep(100)
+        onUpdateCapture.captured("[{\"key\":\"flagkey\",\"variants\":{},\"segments\":[]}]")
+        run.join()
+
+        verify { anyConstructed<SseStream>().connect() }
+        assertContentEquals(arrayOf(listOf(EvaluationFlag("flagkey", emptyMap(), emptyList()))), data)
+
+        api.close()
+    }
+
+    @Test
+    fun `Test conn timeout doesn't block`() {
+        val api = setupApi("deplkey", "https://test.example.com".toHttpUrl(), 500)
+        try {
+            api.connect()
+            fail("Timeout not thrown")
+        } catch (_: FlagConfigStreamApiConnTimeoutError) {
+        }
+        Thread.sleep(100)
+        verify { anyConstructed<SseStream>().cancel() }
+    }
+
+    @Test
+    fun `Test init update failure throws`() {
+        val api = setupApi("deplkey", "https://test.example.com".toHttpUrl(), 2000)
+
+        api.onInitUpdate = { d ->
+            Thread.sleep(2100) // Update time is not included in connection timeout.
+            throw Error()
+        }
+        api.onUpdate = null
+        try {
+            api.connect()
+            fail("Timeout not thrown")
+        } catch (_: FlagConfigStreamApiConnTimeoutError) {
+        }
+        verify { anyConstructed<SseStream>().cancel() }
+    }
+
+    @Test
+    fun `Test init update fallbacks to onUpdate when onInitUpdate = null`() {
+        val api = setupApi("deplkey", "https://test.example.com".toHttpUrl(), 2000)
+
+        api.onInitUpdate = null
+        api.onUpdate = { d ->
+            Thread.sleep(2100) // Update time is not included in connection timeout.
+            throw Error()
+        }
+        try {
+            api.connect()
+            fail("Timeout not thrown")
+        } catch (_: FlagConfigStreamApiConnTimeoutError) {
+        }
+        verify { anyConstructed<SseStream>().cancel() }
+    }
+
+    @Test
+    fun `Test error is passed through onError`() {
+        val api = setupApi("deplkey", "https://test.example.com".toHttpUrl(), 2000)
+
+        val run = async {
+            api.connect()
+        }
+        Thread.sleep(100)
+        onUpdateCapture.captured("[]")
+        run.join()
+
+        assertEquals(0, err.size)
+        onErrorCapture.captured(Error("Haha error"))
+        assertEquals("Stream error", err[0]?.message)
+        assertEquals("Haha error", err[0]?.cause?.message)
+        assertEquals(1, err.size)
+        verify { anyConstructed<SseStream>().cancel() }
+    }
+}
+
+@Suppress("SameParameterValue")
+private fun <T> async(delayMillis: Long = 0L, block: () -> T): CompletableFuture<T> {
+    return if (delayMillis == 0L) {
+        CompletableFuture.supplyAsync(block)
+    } else {
+        val future = CompletableFuture<T>()
+        Experiment.scheduler.schedule({
+            try {
+                future.complete(block.invoke())
+            } catch (t: Throwable) {
+                future.completeExceptionally(t)
+            }
+        }, delayMillis, TimeUnit.MILLISECONDS)
+        future
+    }
+}

--- a/src/test/kotlin/flag/FlagConfigStreamApiTest.kt
+++ b/src/test/kotlin/flag/FlagConfigStreamApiTest.kt
@@ -128,9 +128,9 @@ class FlagConfigStreamApiTest {
         var err: Array<Throwable?> = arrayOf()
 
         val run = async {
-            api.connect({d ->
+            api.connect({ d ->
                 assertEquals(listOf(), d)
-            }, {d ->
+            }, { d ->
                 assertEquals(listOf(), d)
             }, { t ->
                 err += t

--- a/src/test/kotlin/flag/FlagConfigStreamApiTest.kt
+++ b/src/test/kotlin/flag/FlagConfigStreamApiTest.kt
@@ -32,6 +32,11 @@ class FlagConfigStreamApiTest {
         every { anyConstructed<SseStream>().onError = capture(onErrorCapture) } answers {}
     }
 
+    @AfterTest
+    fun afterTest() {
+        clearAllMocks()
+    }
+
     private fun setupApi(
         deploymentKey: String = "",
         serverUrl: HttpUrl = "http://localhost".toHttpUrl(),

--- a/src/test/kotlin/flag/FlagConfigUpdaterTest.kt
+++ b/src/test/kotlin/flag/FlagConfigUpdaterTest.kt
@@ -2,10 +2,18 @@ package com.amplitude.experiment.flag
 
 import com.amplitude.experiment.LocalEvaluationConfig
 import com.amplitude.experiment.evaluation.EvaluationFlag
-import com.amplitude.experiment.util.SseStream
-import io.mockk.*
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Assert.assertEquals
 import java.lang.Exception
-import kotlin.test.*
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.fail
 
 private val FLAG1 = EvaluationFlag("key1", emptyMap(), emptyList())
 private val FLAG2 = EvaluationFlag("key2", emptyMap(), emptyList())
@@ -65,7 +73,7 @@ class FlagConfigPollerTest {
     }
 
     @Test
-    fun `Test Poller start fails`(){
+    fun `Test Poller start fails`() {
         every { fetchApi.getFlagConfigs() } answers { throw Error("Haha error") }
         val poller = FlagConfigPoller(fetchApi, storage, null, null, LocalEvaluationConfig(flagConfigPollerIntervalMillis = 1000))
         var errorCount = 0
@@ -85,7 +93,7 @@ class FlagConfigPollerTest {
     }
 
     @Test
-    fun `Test Poller poll fails`(){
+    fun `Test Poller poll fails`() {
         every { fetchApi.getFlagConfigs() } returns emptyList()
         val poller = FlagConfigPoller(fetchApi, storage, null, null, LocalEvaluationConfig(flagConfigPollerIntervalMillis = 1000))
         var errorCount = 0
@@ -154,7 +162,7 @@ class FlagConfigStreamerTest {
     }
 
     @Test
-    fun `Test Streamer start fails`(){
+    fun `Test Streamer start fails`() {
         every { streamApi.connect(capture(onUpdateCapture), capture(onUpdateCapture), capture(onErrorCapture)) } answers { throw Error("Haha error") }
         val streamer = FlagConfigStreamer(streamApi, storage, null, null)
         var errorCount = 0
@@ -168,7 +176,7 @@ class FlagConfigStreamerTest {
     }
 
     @Test
-    fun `Test Streamer stream fails`(){
+    fun `Test Streamer stream fails`() {
         justRun { streamApi.connect(capture(onUpdateCapture), capture(onUpdateCapture), capture(onErrorCapture)) }
         val streamer = FlagConfigStreamer(streamApi, storage, null, null)
         var errorCount = 0

--- a/src/test/kotlin/flag/FlagConfigUpdaterTest.kt
+++ b/src/test/kotlin/flag/FlagConfigUpdaterTest.kt
@@ -1,0 +1,351 @@
+package com.amplitude.experiment.flag
+
+import com.amplitude.experiment.LocalEvaluationConfig
+import com.amplitude.experiment.evaluation.EvaluationFlag
+import com.amplitude.experiment.util.SseStream
+import io.mockk.*
+import kotlin.test.*
+
+private val FLAG1 = EvaluationFlag("key1", emptyMap(), emptyList())
+private val FLAG2 = EvaluationFlag("key2", emptyMap(), emptyList())
+class FlagConfigPollerTest {
+    private var fetchApi = mockk<FlagConfigApi>()
+    private var storage = InMemoryFlagConfigStorage()
+
+    @BeforeTest
+    fun beforeEach() {
+        fetchApi = mockk<FlagConfigApi>()
+        storage = InMemoryFlagConfigStorage()
+    }
+
+    @Test
+    fun `Test Poller`() {
+        every { fetchApi.getFlagConfigs() } returns emptyList()
+        val poller = FlagConfigPoller(fetchApi, storage, null, null, LocalEvaluationConfig(flagConfigPollerIntervalMillis = 1000))
+        var errorCount = 0
+        poller.start { errorCount++ }
+
+        // start() polls
+        verify(exactly = 1) { fetchApi.getFlagConfigs() }
+        assertEquals(0, storage.getFlagConfigs().size)
+
+        // Poller polls every 1s interval
+        every { fetchApi.getFlagConfigs() } returns listOf(FLAG1)
+        Thread.sleep(1100)
+        verify(exactly = 2) { fetchApi.getFlagConfigs() }
+        assertEquals(1, storage.getFlagConfigs().size)
+        assertEquals(mapOf(FLAG1.key to FLAG1), storage.getFlagConfigs())
+        Thread.sleep(1100)
+        verify(exactly = 3) { fetchApi.getFlagConfigs() }
+
+        // Stop poller stops
+        poller.stop()
+        Thread.sleep(1100)
+        verify(exactly = 3) { fetchApi.getFlagConfigs() }
+
+        // Restart poller
+        every { fetchApi.getFlagConfigs() } returns listOf(FLAG1, FLAG2)
+        poller.start()
+        verify(exactly = 4) { fetchApi.getFlagConfigs() }
+        Thread.sleep(1100)
+        verify(exactly = 5) { fetchApi.getFlagConfigs() }
+        assertEquals(2, storage.getFlagConfigs().size)
+        assertEquals(mapOf(FLAG1.key to FLAG1, FLAG2.key to FLAG2), storage.getFlagConfigs())
+
+        // No errors
+        assertEquals(0, errorCount)
+
+        poller.shutdown()
+    }
+
+    @Test
+    fun `Test Poller start fails`(){
+        every { fetchApi.getFlagConfigs() } answers { throw Error("Haha error") }
+        val poller = FlagConfigPoller(fetchApi, storage, null, null, LocalEvaluationConfig(flagConfigPollerIntervalMillis = 1000))
+        var errorCount = 0
+        try {
+            poller.start { errorCount++ }
+            fail("Poller start error not throwing")
+        } catch (_: Throwable) {
+        }
+        verify(exactly = 1) { fetchApi.getFlagConfigs() }
+
+        // Poller stops
+        Thread.sleep(1100)
+        verify(exactly = 1) { fetchApi.getFlagConfigs() }
+        assertEquals(0, errorCount)
+
+        poller.shutdown()
+    }
+
+    @Test
+    fun `Test Poller poll fails`(){
+        every { fetchApi.getFlagConfigs() } returns emptyList()
+        val poller = FlagConfigPoller(fetchApi, storage, null, null, LocalEvaluationConfig(flagConfigPollerIntervalMillis = 1000))
+        var errorCount = 0
+        poller.start { errorCount++ }
+
+        // Poller start success
+        verify(exactly = 1) { fetchApi.getFlagConfigs() }
+        assertEquals(0, errorCount)
+
+        // Next poll subsequent fails
+        every { fetchApi.getFlagConfigs() } answers { throw Error("Haha error") }
+        Thread.sleep(1100)
+        verify(exactly = 2) { fetchApi.getFlagConfigs() }
+        assertEquals(1, errorCount)
+
+        // Poller stops
+        Thread.sleep(1100)
+        verify(exactly = 2) { fetchApi.getFlagConfigs() }
+        assertEquals(1, errorCount)
+
+        poller.shutdown()
+    }
+}
+
+class FlagConfigStreamerTest {
+    private val onUpdateCapture = slot<((List<EvaluationFlag>) -> Unit)>()
+    private val onErrorCapture = slot<((Throwable?) -> Unit)>()
+    private var streamApi = mockk<FlagConfigStreamApi>()
+    private var storage = InMemoryFlagConfigStorage()
+    private val config = LocalEvaluationConfig(streamUpdates = true, streamServerUrl = "", streamFlagConnTimeoutMillis = 2000)
+
+    @BeforeTest
+    fun beforeEach() {
+        streamApi = mockk<FlagConfigStreamApi>()
+        storage = InMemoryFlagConfigStorage()
+
+        justRun { streamApi.onUpdate = capture(onUpdateCapture) }
+        justRun { streamApi.onError = capture(onErrorCapture) }
+    }
+
+    @Test
+    fun `Test Poller`() {
+        justRun { streamApi.connect() }
+        val streamer = FlagConfigStreamer(streamApi, storage, null, null, config)
+        var errorCount = 0
+        streamer.start { errorCount++ }
+
+        // Streamer starts
+        verify(exactly = 1) { streamApi.connect() }
+
+        // Verify update callback updates storage
+        onUpdateCapture.captured(emptyList())
+        assertEquals(0, storage.getFlagConfigs().size)
+        onUpdateCapture.captured(listOf(FLAG1))
+        assertEquals(mapOf(FLAG1.key to FLAG1), storage.getFlagConfigs())
+        onUpdateCapture.captured(listOf(FLAG1, FLAG2))
+        assertEquals(mapOf(FLAG1.key to FLAG1, FLAG2.key to FLAG2), storage.getFlagConfigs())
+
+        // No extra connect calls
+        verify(exactly = 1) { streamApi.connect() }
+
+        // No errors
+        assertEquals(0, errorCount)
+    }
+
+    @Test
+    fun `Test Streamer start fails`(){
+        every { streamApi.connect() } answers { throw Error("Haha error") }
+        val streamer = FlagConfigStreamer(streamApi, storage, null, null, config)
+        var errorCount = 0
+        try {
+            streamer.start { errorCount++ }
+            fail("Streamer start error not throwing")
+        } catch (_: Throwable) {
+        }
+        verify(exactly = 1) { streamApi.connect() }
+        assertEquals(0, errorCount) // No error callback as it throws directly
+    }
+
+    @Test
+    fun `Test Streamer stream fails`(){
+        every { streamApi.connect() } answers { throw Error("Haha error") }
+        val streamer = FlagConfigStreamer(streamApi, storage, null, null, config)
+        var errorCount = 0
+        streamer.start { errorCount++ }
+
+        // Stream start success
+        verify(exactly = 1) { streamApi.connect() }
+        onUpdateCapture.captured(listOf(FLAG1))
+        assertEquals(mapOf(FLAG1.key to FLAG1), storage.getFlagConfigs())
+        assertEquals(0, errorCount)
+
+        // Stream fails
+        onErrorCapture.captured(Error("Haha error"))
+        assertEquals(1, errorCount) // Error callback is called
+    }
+}
+
+
+class FlagConfigFallbackRetryWrapperTest {
+    private val mainOnErrorCapture = slot<(() -> Unit)>()
+    private val fallbackOnErrorCapture = slot<(() -> Unit)>()
+
+    private var mainUpdater = mockk<FlagConfigUpdater>()
+    private var fallbackUpdater = mockk<FlagConfigUpdater>()
+    @BeforeTest
+    fun beforeEach() {
+        mainUpdater = mockk<FlagConfigUpdater>()
+        fallbackUpdater = mockk<FlagConfigUpdater>()
+
+        justRun { mainUpdater.start(capture(mainOnErrorCapture)) }
+        justRun { mainUpdater.stop() }
+        justRun { mainUpdater.shutdown() }
+        justRun { fallbackUpdater.start(capture(fallbackOnErrorCapture)) }
+        justRun { fallbackUpdater.stop() }
+        justRun { fallbackUpdater.shutdown() }
+    }
+
+    @Test
+    fun `Test FallbackRetryWrapper main updater all success`() {
+        val wrapper = FlagConfigFallbackRetryWrapper(mainUpdater, fallbackUpdater, 1000, 0)
+        var errorCount = 0
+
+        // Main starts
+        wrapper.start { errorCount++ }
+        verify(exactly = 1) { mainUpdater.start(any()) }
+        verify(exactly = 0) { fallbackUpdater.start() }
+        assertEquals(0, errorCount)
+
+        // Stop
+        wrapper.stop()
+        verify(exactly = 1) { mainUpdater.stop() }
+        verify(exactly = 1) { fallbackUpdater.stop() }
+        assertEquals(0, errorCount)
+
+        // Start again
+        wrapper.start { errorCount++ }
+        verify(exactly = 2) { mainUpdater.start(any()) }
+        verify(exactly = 0) { fallbackUpdater.start() }
+        assertEquals(0, errorCount)
+
+        // Shutdown
+        wrapper.shutdown()
+        verify(exactly = 1) { mainUpdater.shutdown() }
+        verify(exactly = 1) { mainUpdater.shutdown() }
+    }
+
+    @Test
+    fun `Test FallbackRetryWrapper main success no fallback updater`() {
+        val wrapper = FlagConfigFallbackRetryWrapper(mainUpdater, null, 1000, 0)
+        var errorCount = 0
+
+        // Main starts
+        wrapper.start { errorCount++ }
+        verify(exactly = 1) { mainUpdater.start(any()) }
+        assertEquals(0, errorCount)
+
+        // Stop
+        wrapper.stop()
+        verify(exactly = 1) { mainUpdater.stop() }
+        assertEquals(0, errorCount)
+
+        // Start again
+        wrapper.start { errorCount++ }
+        verify(exactly = 2) { mainUpdater.start(any()) }
+        assertEquals(0, errorCount)
+
+        // Shutdown
+        wrapper.shutdown()
+        verify(exactly = 1) { mainUpdater.shutdown() }
+    }
+
+    @Test
+    fun `Test FallbackRetryWrapper main start error and retries with no fallback updater`() {
+        val wrapper = FlagConfigFallbackRetryWrapper(mainUpdater, null, 1000, 0)
+        var errorCount = 0
+
+        every { mainUpdater.start(capture(mainOnErrorCapture)) } answers { throw Error() }
+
+        // Main start fail, no error, same as success case
+        wrapper.start { errorCount++ }
+        verify(exactly = 1) { mainUpdater.start(any()) }
+        assertEquals(0, errorCount)
+
+        // Retries start
+        Thread.sleep(1100)
+        verify(exactly = 2) { mainUpdater.start(any()) }
+        assertEquals(0, errorCount)
+
+        wrapper.shutdown()
+    }
+
+    @Test
+    fun `Test FallbackRetryWrapper main error callback and retries with no fallback updater`() {
+        val wrapper = FlagConfigFallbackRetryWrapper(mainUpdater, null, 1000, 0)
+        var errorCount = 0
+
+        // Main start success
+        wrapper.start { errorCount++ }
+        verify(exactly = 1) { mainUpdater.start(any()) }
+        assertEquals(0, errorCount)
+
+        // Signal error
+        mainOnErrorCapture.captured()
+        verify(exactly = 1) { mainUpdater.start(any()) }
+        assertEquals(1, errorCount) // Updater failure from success calls callback
+
+        // Retry fail after 1s
+        every { mainUpdater.start(capture(mainOnErrorCapture)) } answers { throw Error() }
+        Thread.sleep(1100)
+        verify(exactly = 2) { mainUpdater.start(any()) }
+        assertEquals(1, errorCount) // Updater restart error doesn't call callback
+
+        // Retry success after 1s
+        justRun { mainUpdater.start(capture(mainOnErrorCapture)) }
+        Thread.sleep(1100)
+        verify(exactly = 3) { mainUpdater.start(any()) }
+        assertEquals(1, errorCount)
+
+        // No more start
+        Thread.sleep(1100)
+        verify(exactly = 3) { mainUpdater.start(any()) }
+        assertEquals(1, errorCount)
+
+        wrapper.shutdown()
+    }
+
+    @Test
+    fun `Test FallbackRetryWrapper main error callback and retries`() {
+//        val wrapper = FlagConfigFallbackRetryWrapper(mainUpdater, fallbackUpdater, 1000, 0)
+//        var errorCount = 0
+//
+//        // Main start success
+//        wrapper.start { errorCount++ }
+//        verify(exactly = 1) { mainUpdater.start(any()) }
+//        verify(exactly = 0) { fallbackUpdater.start(any()) }
+//        assertEquals(0, errorCount)
+//
+//        // Signal error
+//        mainOnErrorCapture.captured()
+//        verify(exactly = 1) { mainUpdater.start(any()) }
+//        verify(exactly = 1) { fallbackUpdater.start(any()) }
+//        assertEquals(0, errorCount) // Fallback succeeded, so no callback
+//
+//        // Retry fail after 1s
+//        every { mainUpdater.start(capture(mainOnErrorCapture)) } answers { throw Error() }
+//        Thread.sleep(1100)
+//        verify(exactly = 2) { mainUpdater.start(any()) }
+//        verify(exactly = 1) { fallbackUpdater.start(any()) }
+//        assertEquals(0, errorCount)
+//
+//        // Signal fallback fails
+//        fallbackOnErrorCapture.captured()
+//
+//
+//        // Retry success after 1s
+//        justRun { mainUpdater.start(capture(mainOnErrorCapture)) }
+//        Thread.sleep(1100)
+//        verify(exactly = 3) { mainUpdater.start(any()) }
+//        assertEquals(1, errorCount)
+//
+//        // No more start
+//        Thread.sleep(1100)
+//        verify(exactly = 3) { mainUpdater.start(any()) }
+//        assertEquals(1, errorCount)
+//
+//        wrapper.shutdown()
+    }
+}

--- a/src/test/kotlin/flag/FlagConfigUpdaterTest.kt
+++ b/src/test/kotlin/flag/FlagConfigUpdaterTest.kt
@@ -292,16 +292,18 @@ class FlagConfigFallbackRetryWrapperTest {
         wrapper.start()
         verify(exactly = 1) { mainUpdater.start(any()) }
         verify(exactly = 0) { fallbackUpdater.start() }
+        verify(exactly = 1) { fallbackUpdater.stop() }
 
         // Stop
         wrapper.stop()
         verify(exactly = 1) { mainUpdater.stop() }
-        verify(exactly = 1) { fallbackUpdater.stop() }
+        verify(exactly = 2) { fallbackUpdater.stop() }
 
         // Start again
         wrapper.start()
         verify(exactly = 2) { mainUpdater.start(any()) }
         verify(exactly = 0) { fallbackUpdater.start() }
+        verify(exactly = 3) { fallbackUpdater.stop() }
 
         // Shutdown
         wrapper.shutdown()
@@ -373,19 +375,19 @@ class FlagConfigFallbackRetryWrapperTest {
 
         // Retry success
         justRun { mainUpdater.start(capture(mainOnErrorCapture)) }
-        verify(exactly = 0) { fallbackUpdater.stop() }
+        verify(exactly = 1) { fallbackUpdater.stop() }
         Thread.sleep(1100)
         verify(exactly = 3) { mainUpdater.start(any()) }
         verify(exactly = 1) { fallbackUpdater.start(any()) }
         verify(exactly = 0) { mainUpdater.stop() }
-        verify(exactly = 1) { fallbackUpdater.stop() }
+        verify(exactly = 2) { fallbackUpdater.stop() }
 
         // No more start
         Thread.sleep(1100)
         verify(exactly = 3) { mainUpdater.start(any()) }
         verify(exactly = 1) { fallbackUpdater.start(any()) }
         verify(exactly = 0) { mainUpdater.stop() }
-        verify(exactly = 1) { fallbackUpdater.stop() }
+        verify(exactly = 2) { fallbackUpdater.stop() }
 
         wrapper.shutdown()
     }

--- a/src/test/kotlin/util/SseStreamTest.kt
+++ b/src/test/kotlin/util/SseStreamTest.kt
@@ -11,6 +11,7 @@ import okhttp3.Request
 import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
 import org.mockito.Mockito
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -18,7 +19,7 @@ import kotlin.test.assertEquals
 
 class SseStreamTest {
     private val listenerCapture = slot<EventSourceListener>()
-    val clientMock = mockk<OkHttpClient>()
+    private val clientMock = mockk<OkHttpClient>()
     private val es = mockk<EventSource>("mocked es")
 
     private var data: List<String> = listOf()
@@ -33,7 +34,11 @@ class SseStreamTest {
 
         mockkConstructor(OkHttpClient.Builder::class)
         every { anyConstructed<OkHttpClient.Builder>().build() } returns clientMock
+    }
 
+    @AfterTest
+    fun afterTest() {
+        clearAllMocks()
     }
 
     private fun setupStream(

--- a/src/test/kotlin/util/SseStreamTest.kt
+++ b/src/test/kotlin/util/SseStreamTest.kt
@@ -1,0 +1,100 @@
+package com.amplitude.experiment.util
+
+import com.amplitude.experiment.ExperimentUser
+import com.amplitude.experiment.RemoteEvaluationClient
+import io.mockk.*
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.sse.EventSource
+import okhttp3.sse.EventSourceListener
+import org.mockito.Mockito
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+
+class SseStreamTest {
+    private val listenerCapture = slot<EventSourceListener>()
+    val clientMock = mockk<OkHttpClient>()
+    private val es = mockk<EventSource>("mocked es")
+
+    private var data: List<String> = listOf()
+    private var err: List<Throwable?> = listOf()
+
+    @BeforeTest
+    fun beforeTest() {
+        mockkStatic("com.amplitude.experiment.util.RequestKt")
+
+        justRun { es.cancel() }
+        every { clientMock.newEventSource(any(), capture(listenerCapture)) } returns es
+
+        mockkConstructor(OkHttpClient.Builder::class)
+        every { anyConstructed<OkHttpClient.Builder>().build() } returns clientMock
+
+    }
+
+    private fun setupStream(
+        reconnTimeout: Long = 5000
+    ): SseStream {
+        val stream = SseStream("authtoken", "http://localhost".toHttpUrl(), OkHttpClient(), 1000, 1000, reconnTimeout, 0)
+
+        stream.onUpdate = { d ->
+            data += d
+        }
+        stream.onError = { t ->
+            err += t
+        }
+        return stream
+    }
+
+    @Test
+    fun `Test SseStream connect`() {
+        val stream = setupStream()
+        stream.connect()
+
+        listenerCapture.captured.onEvent(es, null, null, "somedata")
+        assertEquals(listOf("somedata"), data)
+        listenerCapture.captured.onFailure(es, null, null)
+        assertEquals("Unknown stream failure", err[0]?.message)
+        listenerCapture.captured.onEvent(es, null, null, "nodata")
+        assertEquals(listOf("somedata"), data)
+
+        stream.cancel()
+    }
+
+    @Test
+    fun `Test SseStream keep alive data omits`() {
+        val stream = setupStream(1000)
+        stream.connect()
+
+        listenerCapture.captured.onEvent(es, null, null, "somedata")
+        assertEquals(listOf("somedata"), data)
+        listenerCapture.captured.onEvent(es, null, null, " ")
+        assertEquals(listOf("somedata"), data)
+
+        stream.cancel()
+    }
+
+    @Test
+    fun `Test SseStream reconnects`() {
+        val stream = setupStream(1000)
+        stream.connect()
+
+        listenerCapture.captured.onEvent(es, null, null, "somedata")
+        assertEquals(listOf("somedata"), data)
+        verify(exactly = 1) {
+            clientMock.newEventSource(allAny(), allAny())
+        }
+
+        Thread.sleep(1100) // Wait 1s for reconnection
+
+        listenerCapture.captured.onEvent(es, null, null, "somedata")
+        assertEquals(listOf("somedata", "somedata"), data)
+        verify(exactly = 2) {
+            clientMock.newEventSource(allAny(), allAny())
+        }
+    }
+}

--- a/src/test/kotlin/util/SseStreamTest.kt
+++ b/src/test/kotlin/util/SseStreamTest.kt
@@ -1,21 +1,21 @@
 package com.amplitude.experiment.util
 
-import com.amplitude.experiment.ExperimentUser
-import com.amplitude.experiment.RemoteEvaluationClient
-import io.mockk.*
-import okhttp3.HttpUrl
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.verify
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
-import okhttp3.Request
 import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
-import org.mockito.Mockito
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
 
 class SseStreamTest {
     private val listenerCapture = slot<EventSourceListener>()

--- a/src/test/kotlin/util/SseStreamTest.kt
+++ b/src/test/kotlin/util/SseStreamTest.kt
@@ -41,24 +41,23 @@ class SseStreamTest {
         clearAllMocks()
     }
 
-    private fun setupStream(
+    private fun setupAndConnectStream(
         reconnTimeout: Long = 5000
     ): SseStream {
         val stream = SseStream("authtoken", "http://localhost".toHttpUrl(), OkHttpClient(), 1000, 1000, reconnTimeout, 0)
 
-        stream.onUpdate = { d ->
+        stream.connect({ d ->
             data += d
-        }
-        stream.onError = { t ->
+        }, { t ->
             err += t
-        }
+        })
+
         return stream
     }
 
     @Test
     fun `Test SseStream connect`() {
-        val stream = setupStream()
-        stream.connect()
+        val stream = setupAndConnectStream()
 
         listenerCapture.captured.onEvent(es, null, null, "somedata")
         assertEquals(listOf("somedata"), data)
@@ -72,8 +71,7 @@ class SseStreamTest {
 
     @Test
     fun `Test SseStream keep alive data omits`() {
-        val stream = setupStream(1000)
-        stream.connect()
+        val stream = setupAndConnectStream(1000)
 
         listenerCapture.captured.onEvent(es, null, null, "somedata")
         assertEquals(listOf("somedata"), data)
@@ -85,8 +83,7 @@ class SseStreamTest {
 
     @Test
     fun `Test SseStream reconnects`() {
-        val stream = setupStream(1000)
-        stream.connect()
+        val stream = setupAndConnectStream(1000)
 
         listenerCapture.captured.onEvent(es, null, null, "somedata")
         assertEquals(listOf("somedata"), data)


### PR DESCRIPTION
Add flag push to JVM SDK. This enables streaming flag changes to clients, instead of polling every x interval. 