### PR TITLE
fix: fix assignment config to use batch when configured

### DIFF
--- a/src/main/kotlin/LocalEvaluationClient.kt
+++ b/src/main/kotlin/LocalEvaluationClient.kt
@@ -84,7 +84,6 @@ class LocalEvaluationClient internal constructor(
                 init(config.assignmentConfiguration.apiKey)
                 setEventUploadThreshold(config.assignmentConfiguration.eventUploadThreshold)
                 setEventUploadPeriodMillis(config.assignmentConfiguration.eventUploadPeriodMillis)
-                useBatchMode(config.assignmentConfiguration.useBatchMode)
                 setOptions(Options().setMinIdLength(1))
                 setServerUrl(getEventServerUrl(config, config.assignmentConfiguration))
             },
@@ -213,8 +212,16 @@ private fun getEventServerUrl(
 ): String {
     return if (assignmentConfiguration.serverUrl == LocalEvaluationConfig.Defaults.EVENT_SERVER_URL) {
         when (config.serverZone) {
-            ServerZone.US -> US_EVENT_SERVER_URL
-            ServerZone.EU -> EU_EVENT_SERVER_URL
+            ServerZone.US -> if (assignmentConfiguration.useBatchMode) {
+                US_BATCH_SERVER_URL
+            } else {
+                US_EVENT_SERVER_URL
+            }
+            ServerZone.EU -> if (assignmentConfiguration.useBatchMode) {
+                EU_BATCH_SERVER_URL
+            } else {
+                EU_EVENT_SERVER_URL
+            }
         }
     } else {
         assignmentConfiguration.serverUrl

--- a/src/main/kotlin/ServerZone.kt
+++ b/src/main/kotlin/ServerZone.kt
@@ -6,6 +6,8 @@ internal const val US_COHORT_SERVER_URL = "https://cohort-v2.lab.amplitude.com"
 internal const val EU_COHORT_SERVER_URL = "https://cohort-v2.lab.eu.amplitude.com"
 internal const val US_EVENT_SERVER_URL = "https://api2.amplitude.com/2/httpapi"
 internal const val EU_EVENT_SERVER_URL = "https://api.eu.amplitude.com/2/httpapi"
+internal const val US_BATCH_SERVER_URL = "https://api2.amplitude.com/batch"
+internal const val EU_BATCH_SERVER_URL = "https://api.eu.amplitude.com/batch"
 
 enum class ServerZone {
     US, EU


### PR DESCRIPTION
The `setServerUrl` call was overwriting the call to `useBatchMode`.

simply use the useBatchMode value to get the server url