### PR TITLE
chore: bump amplitude java sdk version

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -7,7 +7,7 @@ object Versions {
     const val json = "20231013"
     const val okhttp = "4.12.0"
     const val evaluationCore = "2.0.0-beta.2"
-    const val amplitudeAnalytics = "1.12.0"
+    const val amplitudeAnalytics = "1.12.3"
     const val mockk = "1.13.9"
     const val mockito = "4.8.1"
     const val mockwebserver = "4.12.0"


### PR DESCRIPTION
The new Amplitude Java SDK version 1.12.3 passes error to callback. This allows more transparent errors when assignment events failed to send. 