### PR TITLE
fix: tests assertion ignore evaluationId

### DIFF
--- a/src/test/kotlin/RemoteEvaluationClientTest.kt
+++ b/src/test/kotlin/RemoteEvaluationClientTest.kt
@@ -24,14 +24,12 @@ fun assertVariantEquals(
     expected: Variant,
     actual: Variant?,
 ) {
-    val metadata = when {
-        expected.metadata != null -> expected.metadata?.toMutableMap()
-        actual?.metadata != null -> mutableMapOf()
-        else -> null
+    Assert.assertEquals(expected.key, actual?.key)
+    Assert.assertEquals(expected.value, actual?.value)
+    Assert.assertEquals(expected.payload, actual?.payload)
+    if (expected.metadata?.get("evaluationId") != null) {
+        Assert.assertNotNull(actual?.metadata?.get("evaluationId"))
     }
-    metadata?.set("evaluationId", actual?.metadata?.get("evaluationId"))
-    val matchedVariant = Variant(expected.value, expected.payload, expected.key, metadata)
-    Assert.assertEquals(matchedVariant, actual)
 }
 
 class RemoteEvaluationClientTest {

--- a/src/test/kotlin/RemoteEvaluationClientTest.kt
+++ b/src/test/kotlin/RemoteEvaluationClientTest.kt
@@ -41,7 +41,7 @@ class RemoteEvaluationClientTest {
     }
 
     private val testFlagKey = "sdk-ci-test"
-    private val testVariant = Variant(key = "on", value = "on", payload = "payload")
+    private val testVariant = Variant(key = "on", value = "on", payload = "payload", metadata = mapOf("evaluationId" to ""))
 
     private val testUser = ExperimentUser(userId = "test_user")
 

--- a/src/test/kotlin/RemoteEvaluationClientTest.kt
+++ b/src/test/kotlin/RemoteEvaluationClientTest.kt
@@ -16,6 +16,24 @@ import kotlin.test.fail
 
 private const val API_KEY = "server-qz35UwzJ5akieoAdIgzM4m9MIiOLXLoz"
 
+/**
+ * To assert two variants. These fields are not consistent across evaluation, simply assert not null.
+ * - metadata.evaluationId
+ */
+fun assertVariantEquals(
+    expected: Variant,
+    actual: Variant?,
+) {
+    val metadata = when {
+        expected.metadata != null -> expected.metadata?.toMutableMap()
+        actual?.metadata != null -> mutableMapOf()
+        else -> null
+    }
+    metadata?.set("evaluationId", actual?.metadata?.get("evaluationId"))
+    val matchedVariant = Variant(expected.value, expected.payload, expected.key, metadata)
+    Assert.assertEquals(matchedVariant, actual)
+}
+
 class RemoteEvaluationClientTest {
 
     init {
@@ -40,7 +58,7 @@ class RemoteEvaluationClientTest {
         println(dur)
         Assert.assertNotNull(variants)
         val variant = variants[testFlagKey]
-        Assert.assertEquals(testVariant, variant)
+        assertVariantEquals(testVariant, variant)
     }
 
     @Test


### PR DESCRIPTION
Ignore evaluationId in metadata. 