### PR TITLE
fix: update evaluation dependency for parity with remote assignment

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -7,7 +7,7 @@ object Versions {
     const val json = "20231013"
     const val okhttp = "4.12.0"
     const val okhttpSse = "4.12.0" // Update this alongside okhttp. Note this library isn't stable and may contain breaking changes. Search uses of okhttp3.internal classes before updating.
-    const val evaluationCore = "2.0.0-beta.2"
+    const val evaluationCore = "2.3.0"
     const val amplitudeAnalytics = "1.12.3"
     const val mockk = "1.13.9"
     const val mockito = "4.8.1"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Dependency bump from a beta (`2.0.0-beta.2`) to `2.3.0` may introduce behavioral or API changes in evaluation logic at runtime, even though the code change is a single version constant.
> 
> **Overview**
> Updates the pinned `evaluationCore` dependency version in `buildSrc/src/main/kotlin/Versions.kt` from `2.0.0-beta.2` to `2.3.0` to align with the remote assignment/evaluation stack.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71ad1fc810c620f0200526fd615d46ad06154ccb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->