### PR TITLE
fix: include experiment key on local-eval exposure events

### DIFF
--- a/src/main/kotlin/exposure/ExposureService.kt
+++ b/src/main/kotlin/exposure/ExposureService.kt
@@ -96,6 +96,10 @@ internal fun Exposure.toAmplitudeEvent(): List<Event> {
             } else if (variant.value != null) {
                 put("[Experiment] Variant", variant.value)
             }
+            val experimentKey = variant.metadata?.get("experimentKey") as? String
+            if (experimentKey != null) {
+                put("[Experiment] Experiment Key", experimentKey)
+            }
             if (variant.metadata != null) {
                 put("metadata", JSONObject(variant.metadata.toMap()))
             }

--- a/src/test/kotlin/exposure/ExposureServiceTest.kt
+++ b/src/test/kotlin/exposure/ExposureServiceTest.kt
@@ -27,11 +27,22 @@ class ExposureServiceTest {
                     "default" to true,
                 )
             ),
+            "with-experiment-key" to Variant(
+                key = "treatment",
+                value = "treatment",
+                metadata = mapOf(
+                    "segmentName" to "All Other Users",
+                    "flagType" to "experiment",
+                    "flagVersion" to 10,
+                    "default" to false,
+                    "experimentKey" to "exp-1",
+                )
+            ),
             "empty-variant" to Variant()
         )
         val exposure = Exposure(user, results)
         val events = exposure.toAmplitudeEvent()
-        Assert.assertEquals(2, events.size)
+        Assert.assertEquals(3, events.size)
         for (event in events) {
             Assert.assertEquals(user.userId, event.userId)
             Assert.assertEquals(user.deviceId, event.deviceId)
@@ -39,6 +50,12 @@ class ExposureServiceTest {
 
             val flagKey = event.eventProperties?.getString("[Experiment] Flag Key")
             Assert.assertEquals(results[flagKey]?.key, if (event.eventProperties.has("[Experiment] Variant")) event.eventProperties.getString("[Experiment] Variant") else null)
+
+            if (flagKey == "with-experiment-key") {
+                Assert.assertEquals("exp-1", event.eventProperties.getString("[Experiment] Experiment Key"))
+            } else {
+                Assert.assertFalse(event.eventProperties.has("[Experiment] Experiment Key"))
+            }
 
             val userProperties = event.userProperties
             Assert.assertEquals(2, userProperties.length())
@@ -54,7 +71,7 @@ class ExposureServiceTest {
             }
             Assert.assertEquals(0, userProperties.getJSONObject("\$unset").length())
 
-            val canonicalization = "user device empty-variant null flag-key-1 on flag-key-2 off "
+            val canonicalization = "user device empty-variant null flag-key-1 on flag-key-2 off with-experiment-key treatment "
             val expected = "user device ${("$flagKey $canonicalization").hashCode()} ${exposure.timestamp / DAY_MILLIS}"
             Assert.assertEquals(expected, event.insertId)
         }


### PR DESCRIPTION
## Summary

- Local evaluation exposure events from `Exposure.toAmplitudeEvent()` carried `experimentKey` only inside the `metadata` blob — the top-level event property `[Experiment] Experiment Key` was never set, so custom reports keying off it saw no value for local-eval customers.
- Fix: when `variant.metadata["experimentKey"]` is non-null, set `event.eventProperties["[Experiment] Experiment Key"]`. Additive and backwards-compatible — `metadata`, `[Experiment] Flag Key`, `[Experiment] Variant`, user properties, and `insertId` are unchanged.
- Mirrors [amplitude/experiment-node-server#83](https://github.com/amplitude/experiment-node-server/pull/83).

## Test plan

- [x] Added `with-experiment-key` fixture to `ExposureServiceTest`. Asserts `[Experiment] Experiment Key` equals `"exp-1"` for that flag and is absent for the others.
- [x] Updated event count and canonicalization expectation accordingly.
- [x] `./gradlew test --tests "com.amplitude.experiment.exposure.ExposureServiceTest"` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive change: only adds an optional top-level event property derived from existing `variant.metadata`, with a small test update to cover it.
> 
> **Overview**
> Local-eval exposure events now include a top-level `[Experiment] Experiment Key` in `eventProperties` when `variant.metadata["experimentKey"]` is present, instead of only embedding it inside the `metadata` blob.
> 
> Tests add a `with-experiment-key` fixture and assert the new field is set only for that flag, updating expected event count and `insertId` canonicalization accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2314e1dba028cdc911e4e875dd014d69ad1eef40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->