### PR TITLE
feat: allow custom HTTP client for remote evaluation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinJvm
 
 plugins {
+    `java-library`
     kotlin("jvm")
     kotlin("plugin.serialization") version Versions.serializationPlugin
     id("com.vanniktech.maven.publish") version Versions.vanniktechMavenPublish
@@ -32,7 +33,7 @@ dependencies {
     testImplementation("io.mockk:mockk:${Versions.mockk}")
     testImplementation("io.github.cdimascio:dotenv-kotlin:${Versions.dotenvKotlin}")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.serializationRuntime}")
-    implementation("com.squareup.okhttp3:okhttp:${Versions.okhttp}")
+    api("com.squareup.okhttp3:okhttp:${Versions.okhttp}")
     implementation("com.squareup.okhttp3:okhttp-sse:${Versions.okhttpSse}")
     implementation("com.amplitude:evaluation-core:${Versions.evaluationCore}")
     implementation("com.amplitude:java-sdk:${Versions.amplitudeAnalytics}")

--- a/src/main/kotlin/Experiment.kt
+++ b/src/main/kotlin/Experiment.kt
@@ -1,6 +1,7 @@
 package com.amplitude.experiment
 
 import com.amplitude.experiment.util.Logger
+import okhttp3.OkHttpClient
 import java.util.concurrent.Executors
 
 internal const val LIBRARY_VERSION = "1.8.3"
@@ -24,20 +25,54 @@ object Experiment {
     fun initializeRemote(
         apiKey: String,
         config: RemoteEvaluationConfig = RemoteEvaluationConfig()
+    ): RemoteEvaluationClient = getOrCreateRemote(apiKey, config) {
+        RemoteEvaluationClient(
+            apiKey,
+            config,
+        )
+    }
+
+    /**
+     * Initializes a singleton [RemoteEvaluationClient] with a caller-provided [OkHttpClient].
+     * Subsequent calls with the same API key return the existing instance, regardless of config or
+     * HTTP client.
+     *
+     * The caller owns the HTTP client's lifecycle. When a custom client is provided,
+     * [RemoteEvaluationConfig.httpProxy] is ignored; configure the proxy on [httpClient] instead.
+     *
+     * @param apiKey The API key. This can be found in the Experiment settings and should not be null or empty.
+     * @param config see [RemoteEvaluationConfig] for configuration options
+     * @param httpClient the HTTP client used for remote evaluation requests
+     */
+    @JvmStatic
+    fun initializeRemote(
+        apiKey: String,
+        config: RemoteEvaluationConfig,
+        httpClient: OkHttpClient,
+    ): RemoteEvaluationClient = getOrCreateRemote(apiKey, config) {
+        RemoteEvaluationClient(
+            apiKey,
+            config,
+            httpClient,
+        )
+    }
+
+    private fun getOrCreateRemote(
+        apiKey: String,
+        config: RemoteEvaluationConfig,
+        createClient: () -> RemoteEvaluationClient,
     ): RemoteEvaluationClient = synchronized(remoteInstances) {
         return when (val instance = remoteInstances[apiKey]) {
             null -> {
                 Logger.configure(config.logLevel, config.loggerProvider)
-                val newInstance = RemoteEvaluationClient(
-                    apiKey,
-                    config,
-                )
+                val newInstance = createClient()
                 remoteInstances[apiKey] = newInstance
                 newInstance
             }
             else -> instance
         }
     }
+
     /**
      * Initializes a singleton [LocalEvaluationClient] instance. Subsequent calls will return the
      * same instance, regardless of api key or config.

--- a/src/main/kotlin/RemoteEvaluationClient.kt
+++ b/src/main/kotlin/RemoteEvaluationClient.kt
@@ -22,10 +22,19 @@ import java.util.concurrent.TimeUnit
 
 class RemoteEvaluationClient internal constructor(
     private val apiKey: String,
-    private val config: RemoteEvaluationConfig = RemoteEvaluationConfig(),
+    private val config: RemoteEvaluationConfig,
+    private val httpClient: OkHttpClient,
 ) {
 
-    private val httpClient = OkHttpClient.Builder().proxy(config.httpProxy).build()
+    internal constructor(
+        apiKey: String,
+        config: RemoteEvaluationConfig = RemoteEvaluationConfig(),
+    ) : this(
+        apiKey,
+        config,
+        OkHttpClient.Builder().proxy(config.httpProxy).build(),
+    )
+
     private val retry: Boolean = config.fetchRetries > 0
     private val serverUrl: HttpUrl = getServerUrl(config)
     private val backoffConfig = BackoffConfig(

--- a/src/test/kotlin/RemoteEvaluationClientTest.kt
+++ b/src/test/kotlin/RemoteEvaluationClientTest.kt
@@ -8,6 +8,8 @@ import io.mockk.every
 import io.mockk.spyk
 import io.mockk.verify
 import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert
 import java.util.Date
 import java.util.concurrent.CancellationException
@@ -164,16 +166,12 @@ class RemoteEvaluationClientTest {
 
     @Test
     fun `test fetch with fetch options`() {
+        val httpClient = spyk(OkHttpClient())
         val client = RemoteEvaluationClient(
             API_KEY,
             RemoteEvaluationConfig(debug = true),
+            httpClient,
         )
-
-        // Use reflection to spy on private httpClient field
-        val httpClient = spyk(OkHttpClient())
-        val httpClientField = RemoteEvaluationClient::class.java.getDeclaredField("httpClient")
-        httpClientField.isAccessible = true
-        httpClientField.set(client, httpClient)
 
         val variants = client.fetch(
             testUser,
@@ -210,6 +208,26 @@ class RemoteEvaluationClientTest {
                     it.headers["X-Amp-Exp-Track"] == null && it.headers["X-Amp-Exp-Exposure-Track"] == null
                 }
             )
+        }
+    }
+
+    @Test
+    fun `test initialize remote with custom http client`() {
+        MockWebServer().use { server ->
+            server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+            val httpClient = spyk(OkHttpClient())
+            val config = RemoteEvaluationConfig.builder()
+                .serverUrl(server.url("/").toString())
+                .fetchRetries(0)
+                .build()
+            val client = Experiment.initializeRemote(
+                "custom-http-client-${System.nanoTime()}",
+                config,
+                httpClient,
+            )
+
+            Assert.assertTrue(client.fetch(testUser).get().isEmpty())
+            verify(exactly = 1) { httpClient.newCall(any()) }
         }
     }
 }


### PR DESCRIPTION
## Summary

- add an `Experiment.initializeRemote` overload that accepts a caller-owned `OkHttpClient`
- preserve the existing default client construction and singleton behavior
- publish OkHttp as an API dependency because it is now part of the public method signature
- replace reflection-based client injection in tests with constructor injection and add MockWebServer coverage for the public overload

## Motivation

This addresses the transport configurability requested in #54.

Remote evaluation currently constructs a private `OkHttpClient`, so applications cannot configure connection health behavior such as HTTP/2 pings or select a protocol policy. A half-open pooled connection can therefore continue to be reused until the operating system closes it.

The overload lets applications provide a client configured for their environment:

```java
OkHttpClient httpClient = new OkHttpClient.Builder()
    .pingInterval(30, TimeUnit.SECONDS)
    .build();

RemoteEvaluationClient client =
    Experiment.initializeRemote(apiKey, config, httpClient);
```

This change does not alter the SDK default transport policy. When a custom client is supplied, the caller owns its lifecycle and must configure any proxy directly on that client.

## Compatibility

- existing one- and two-argument `initializeRemote` Java overloads are unchanged
- existing default `RemoteEvaluationClient` construction is unchanged
- custom clients still use the SDK fetch timeout through the per-call timeout

## Verification

- `./gradlew ktlintCheck assemble generatePomFileForMavenPublication`
- `./gradlew test --tests com.amplitude.experiment.RemoteEvaluationClientTest`
- focused test and assembly also pass on Java 21
- generated POM publishes OkHttp with compile scope

The full suite completed 132 of 134 tests successfully. The two failures are existing live stream-server tests whose source explicitly marks them as potentially flaky:

- `LocalEvaluationClientTest.evaluate with user, stream flags, cohort segment targeted`
- `StreamTest.test SDK stream is compatible with stream server (flaky possible, see comments)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible API extension with unchanged default transport; main consumer impact is OkHttp appearing on the compile classpath via `api` scope.
> 
> **Overview**
> Adds a third **`Experiment.initializeRemote`** overload that accepts a caller-owned **`OkHttpClient`**, so apps can tune transport (e.g. HTTP/2 ping intervals) instead of relying on the SDK’s internal client. **`RemoteEvaluationClient`** now takes the client via constructor injection; the default path still builds a client from **`RemoteEvaluationConfig.httpProxy`**, and docs note that **`httpProxy`** is ignored when a custom client is supplied.
> 
> Remote singleton creation is refactored through **`getOrCreateRemote`** with a factory lambda so both init paths share the same behavior. **Gradle** applies **`java-library`** and exposes OkHttp as an **`api`** dependency because **`OkHttpClient`** is part of the public API.
> 
> Tests drop reflection-based HTTP client injection in favor of constructor injection and add **MockWebServer** coverage for the new **`initializeRemote`** overload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 739512983bfc04a9695fa140bd88188c1ef94e4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->